### PR TITLE
Improve .chart interpreter to allow for quotation marks in lyrics

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -500,7 +500,21 @@ namespace MoonscraperChartEditor.Song.IO
 
                         for (int i = startIndex; i < stringSplit.Length; ++i)
                         {
-                            sb.Append(stringSplit[i].Trim('"'));
+                            int wordLength = stringSplit[i].Length;
+                            string tempWord = stringSplit[i];
+                            // Remove closing quote on last word
+                            if ((i == stringSplit.Length - 1) && (stringSplit[i][wordLength - 1] == '"'))
+                                tempWord = (tempWord.Remove(wordLength - 1));
+                            // Remove opening quote on fourth word
+                            if ((i == 3) && (tempWord[0] == '"'))
+                                tempWord = (tempWord.Substring(1));
+                            // Remove any quotes before the event starts
+                            else if (i < 3)
+                                tempWord = (tempWord.Trim('"'));
+                            // Keep formatting intact for any other word
+
+                            sb.Append(tempWord);
+
                             if (i < stringSplit.Length - 1)
                                 sb.Append(" ");
                         }


### PR DESCRIPTION
Currently, the code that interprets global events when loading a .chart file removes all quotation marks from the event before continuing to process its content. By instead removing only the opening and closing quotes for a global event, embedded quotes can be accurately retained.

From my tests, Clone Hero already supports quotation marks in lyric events without any escape characters using a similar strategy for reading .chart files.