### PR TITLE
Add Support for Rhythm Difficulty in `song.ini`

### DIFF
--- a/Moonscraper Chart Editor/Assets/ExtraBuildFiles/Config/clone_hero_ini_tags.txt
+++ b/Moonscraper Chart Editor/Assets/ExtraBuildFiles/Config/clone_hero_ini_tags.txt
@@ -1,5 +1,6 @@
 diff_band = -1
 diff_guitar = -1
+diff_rhythm = -1
 diff_bass = -1
 diff_drums = -1
 diff_keys = -1

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/SongIniFunctions.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/SongIniFunctions.cs
@@ -73,6 +73,9 @@ public static class SongIniFunctions
             case Song.Instrument.Guitar:
                 return "diff_guitar";
 
+            case Song.Instrument.Rhythm:
+                return "diff_rhythm";
+
             case Song.Instrument.Bass:
                 return "diff_bass";
 


### PR DESCRIPTION
Small patch to add and support `diff_rhythm` being in the `song.ini`. Pretty simple and straight forward. Hopefully I didn't miss any other references in the code (I only used GitHub's search function, which isn't great). Probably won't get used much, but I'm OCD when it comes to missing, yet valid, values, haha.

NOTE: I only added lines 76-78 to `SongIniFunctions.cs`; not sure why GitHub's difference viewer is freaking out and showing so many other changes when there is none (I even edited the file on GitHub's website).