### PR TITLE
extend extension check to ".CHA"

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -112,7 +112,7 @@ namespace MoonscraperChartEditor.Song.IO
                     throw new Exception("File does not exist");
 
                 string extension = Path.GetExtension(filepath);
-                bool standardChartFormat = extension == ".chart";
+                bool standardChartFormat = extension == ".chart" || extension == ".CHA";
 
                 if (standardChartFormat || extension == MsceIOHelper.FileExtention)
                 {


### PR DESCRIPTION
When attempting to load a chart with a total path length longer than 260 characters, Windows returns a extended-length path with shortened folder names. This also causes the extension to be changed to ".CHA".

The chart is loaded fine if the line that checks for a valid extension also includes this shortened extnesion.