### PR TITLE
.mid parser: reworks and feature additions

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/ChartEditorExtentions/NoteFunctions.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/ChartEditorExtentions/NoteFunctions.cs
@@ -289,6 +289,29 @@ public static class NoteFunctions {
         return flags;
     }
 
+    public static bool IsAllowedToBeType(this Note note, Note.NoteType type)
+    {
+        switch (type)
+        {
+            case (Note.NoteType.Natural):
+            case (Note.NoteType.Strum):
+                return true;
+
+            case (Note.NoteType.Hopo):
+                return !note.cannotBeForced;
+
+            case (Note.NoteType.Tap):
+                return !note.IsOpenNote();
+
+            case (Note.NoteType.Cymbal):
+                return NoteFunctions.AllowedToBeCymbal(note);
+
+            default:
+                // Assume no for future note types that haven't been added here yet
+                return false;
+        }
+    }
+
     public static int ExpensiveGetExtendedSustainMask(this Note note)
     {
         int mask = 0;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Events/Note.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Events/Note.cs
@@ -498,7 +498,7 @@ namespace MoonscraperChartEditor.Song
                 case Chart.GameMode.Guitar:
                 case Chart.GameMode.GHLGuitar:
                     {
-                        bannedFlags = Flags.ProDrums_Cymbal;
+                        bannedFlags = Flags.ProDrums_Cymbal | Flags.ProDrums_Accent | Flags.ProDrums_Ghost;
                         break;
                     }
                 case Chart.GameMode.Drums:

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -20,6 +20,30 @@ namespace MoonscraperChartEditor.Song.IO
         public const string GHL_BASS_TRACK = "PART BASS GHL";
         public const string VOCALS_TRACK = "PART VOCALS";
 
+        public static readonly Dictionary<Song.Difficulty, int> GUITAR_DIFF_RANGE_LOOKUP = new Dictionary<Song.Difficulty, int>()
+    {
+        { Song.Difficulty.Easy, 60 },
+        { Song.Difficulty.Medium, 72 },
+        { Song.Difficulty.Hard, 84 },
+        { Song.Difficulty.Expert, 96 }
+    };
+
+        public static readonly Dictionary<Song.Difficulty, int> GHL_GUITAR_DIFF_RANGE_LOOKUP = new Dictionary<Song.Difficulty, int>()
+    {
+        { Song.Difficulty.Easy, 58 },
+        { Song.Difficulty.Medium, 70 },
+        { Song.Difficulty.Hard, 82 },
+        { Song.Difficulty.Expert, 94 }
+    };
+
+        public static readonly Dictionary<Song.Difficulty, int> DRUMS_DIFF_RANGE_LOOKUP = new Dictionary<Song.Difficulty, int>()
+    {
+        { Song.Difficulty.Easy, 60 },
+        { Song.Difficulty.Medium, 72 },
+        { Song.Difficulty.Hard, 84 },
+        { Song.Difficulty.Expert, 96 }
+    };
+
         public const string LYRIC_EVENT_PREFIX = LyricHelper.LYRIC_EVENT_PREFIX;
         public const byte SOLO_NOTE = 0x67;                 // 103, http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
         public const byte STARPOWER_NOTE = 0x74;            // 116, http://docs.c3universe.com/rbndocs/index.php?title=Overdrive_and_Big_Rock_Endings

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -11,11 +11,13 @@ namespace MoonscraperChartEditor.Song.IO
     {
         public const string EVENTS_TRACK = "EVENTS";           // Sections
         public const string GUITAR_TRACK = "PART GUITAR";
+        public const string GH1_GUITAR_TRACK = "T1 GEMS";
         public const string GUITAR_COOP_TRACK = "PART GUITAR COOP";
         public const string BASS_TRACK = "PART BASS";
         public const string RHYTHM_TRACK = "PART RHYTHM";
         public const string KEYS_TRACK = "PART KEYS";
         public const string DRUMS_TRACK = "PART DRUMS";
+        public const string DRUMS_REAL_TRACK = "PART REAL_DRUMS_PS";
         public const string GHL_GUITAR_TRACK = "PART GUITAR GHL";
         public const string GHL_BASS_TRACK = "PART BASS GHL";
         public const string VOCALS_TRACK = "PART VOCALS";

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -46,6 +46,7 @@ namespace MoonscraperChartEditor.Song.IO
 
         public const string LYRIC_EVENT_PREFIX = LyricHelper.LYRIC_EVENT_PREFIX;
         public const byte SOLO_NOTE = 0x67;                 // 103, http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
+        public const byte TAP_NOTE = 0x68;                  // 104, https://strikeline.myjetbrains.com/youtrack/issue/CH-390
         public const byte STARPOWER_NOTE = 0x74;            // 116, http://docs.c3universe.com/rbndocs/index.php?title=Overdrive_and_Big_Rock_Endings
 
         // 120 - 124 http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -436,7 +436,6 @@ namespace MoonscraperChartEditor.Song.IO
 
         private static void ReadNotes(IList<MidiEvent> track, Song song, Song.Instrument instrument, ref CallbackState callBackState)
         {
-            List<NoteOnEvent> forceNotesList = new List<NoteOnEvent>();
             List<SysexEvent> tapAndOpenEvents = new List<SysexEvent>();
 
             Chart unrecognised = new Chart(song, Song.Instrument.Unrecognised);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -353,7 +353,6 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ReadNotes(IList<MidiEvent> track, Song song, Song.Instrument instrument)
         {
             List<NoteOnEvent> forceNotesList = new List<NoteOnEvent>();
-            List<NoteOnEvent> proDrumsNotesList = new List<NoteOnEvent>();
             List<SysexEvent> tapAndOpenEvents = new List<SysexEvent>();
 
             Chart unrecognised = new Chart(song, Song.Instrument.Unrecognised);
@@ -580,42 +579,6 @@ namespace MoonscraperChartEditor.Song.IO
                             case (Chart.GameMode.Drums):
                                 notes[k].guitarFret = LoadDrumNoteToGuitarNote(notes[k].guitarFret);
                                 break;
-                        }
-                    }
-                }
-            }
-
-            foreach (var flagEvent in proDrumsNotesList)
-            {
-                uint tick = (uint)flagEvent.AbsoluteTime;
-                uint endPos = (uint)(flagEvent.OffEvent.AbsoluteTime - tick);
-                if (endPos > 0)
-                    --endPos;
-
-                Debug.Assert(instrument == Song.Instrument.Drums);
-
-                foreach (Song.Difficulty difficulty in EnumX<Song.Difficulty>.Values)
-                {
-                    Chart chart = song.GetChart(instrument, difficulty);
-
-                    int index, length;
-                    SongObjectHelper.GetRange(chart.notes, tick, tick + endPos, out index, out length);
-
-                    Note.DrumPad drumPadForFlag;
-                    if (!MidIOHelper.CYMBAL_TO_PAD_LOOKUP.TryGetValue(flagEvent.NoteNumber, out drumPadForFlag))
-                    {
-                        Debug.Assert(false, "Unknown note number flag " + flagEvent.NoteNumber);
-                        continue;
-                    }
-
-                    for (int i = index; i < index + length; ++i)
-                    {
-                        Note note = chart.notes[i];
-
-                        if (note.drumPad == drumPadForFlag)
-                        {
-                            // Reverse cymbal flag
-                            note.flags ^= Note.Flags.ProDrums_Cymbal;
                         }
                     }
                 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -620,11 +620,6 @@ namespace MoonscraperChartEditor.Song.IO
         delegate void BuildPerDifficultyFn(int difficultyStartRange, Song.Difficulty difficulty);
         static void BuildGuitarMidiNoteNumberToProcessFnDict()
         {
-            const int EasyStartRange = 60;
-            const int MediumStartRange = 72;
-            const int HardStartRange = 84;
-            const int ExpertStartRange = 96;
-
             Dictionary<Note.GuitarFret, int> FretToMidiKey = new Dictionary<Note.GuitarFret, int>()
         {
             // { Note.GuitarFret.Open, 0 }, // Handled by sysex event
@@ -669,19 +664,16 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            BuildPerDifficulty(EasyStartRange, Song.Difficulty.Easy);
-            BuildPerDifficulty(MediumStartRange, Song.Difficulty.Medium);
-            BuildPerDifficulty(HardStartRange, Song.Difficulty.Hard);
-            BuildPerDifficulty(ExpertStartRange, Song.Difficulty.Expert);
+            foreach (var keyVal in MidIOHelper.GUITAR_DIFF_RANGE_LOOKUP)
+            {
+                var diff = keyVal.Key;
+                var rangeStart = keyVal.Value;
+                BuildPerDifficulty(rangeStart, diff);
+            }
         }
 
         static void BuildGhlGuitarMidiNoteNumberToProcessFnDict()
         {
-            const int EasyStartRange = 58;
-            const int MediumStartRange = 70;
-            const int HardStartRange = 82;
-            const int ExpertStartRange = 94;
-
             Dictionary<Note.GHLiveGuitarFret, int> FretToMidiKey = new Dictionary<Note.GHLiveGuitarFret, int>()
         {
             { Note.GHLiveGuitarFret.Open, 0 },
@@ -727,19 +719,16 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            BuildPerDifficulty(EasyStartRange, Song.Difficulty.Easy);
-            BuildPerDifficulty(MediumStartRange, Song.Difficulty.Medium);
-            BuildPerDifficulty(HardStartRange, Song.Difficulty.Hard);
-            BuildPerDifficulty(ExpertStartRange, Song.Difficulty.Expert);
+            foreach (var keyVal in MidIOHelper.GHL_GUITAR_DIFF_RANGE_LOOKUP)
+            {
+                var diff = keyVal.Key;
+                var rangeStart = keyVal.Value;
+                BuildPerDifficulty(rangeStart, diff);
+            }
         }
 
         static void BuildDrumsMidiNoteNumberToProcessFnDict()
         {
-            const int EasyStartRange = 60;
-            const int MediumStartRange = 72;
-            const int HardStartRange = 84;
-            const int ExpertStartRange = 96;
-
             Dictionary<Note.DrumPad, int> DrumPadToMidiKey = new Dictionary<Note.DrumPad, int>()
         {
             { Note.DrumPad.Kick, 0 },
@@ -796,10 +785,12 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            BuildPerDifficulty(EasyStartRange, Song.Difficulty.Easy);
-            BuildPerDifficulty(MediumStartRange, Song.Difficulty.Medium);
-            BuildPerDifficulty(HardStartRange, Song.Difficulty.Hard);
-            BuildPerDifficulty(ExpertStartRange, Song.Difficulty.Expert);
+            foreach (var keyVal in MidIOHelper.DRUMS_DIFF_RANGE_LOOKUP)
+            {
+                var diff = keyVal.Key;
+                var rangeStart = keyVal.Value;
+                BuildPerDifficulty(rangeStart, diff);
+            }
 
             foreach (var keyVal in MidIOHelper.PAD_TO_CYMBAL_LOOKUP)
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -258,7 +258,7 @@ namespace MoonscraperChartEditor.Song.IO
                             }
 
                             Debug.LogFormat("Loading midi track {0}", instrument);
-                            ReadNotes(midi.Events[i], song, instrument);
+                            ReadNotes(midi.Events[i], song, instrument, ref callBackState);
                             break;
                         }
                 }
@@ -388,7 +388,7 @@ namespace MoonscraperChartEditor.Song.IO
             song.UpdateCache();
         }
 
-        private static void ReadNotes(IList<MidiEvent> track, Song song, Song.Instrument instrument)
+        private static void ReadNotes(IList<MidiEvent> track, Song song, Song.Instrument instrument, ref CallbackState callBackState)
         {
             List<NoteOnEvent> forceNotesList = new List<NoteOnEvent>();
             List<SysexEvent> tapAndOpenEvents = new List<SysexEvent>();

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -40,7 +40,8 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly Dictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
     {
-        { "beat",       true },
+        { "BEAT",       true },
+        { "VENUE",      true },
     };
 
         static readonly List<Song.Instrument> c_legacyStarPowerFixupWhitelist = new List<Song.Instrument>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -186,13 +186,13 @@ namespace MoonscraperChartEditor.Song.IO
                     bool importTrackAsVocalsEvents = trackNameKey == MidIOHelper.VOCALS_TRACK;
 
 #if !UNITY_EDITOR
-                if (importTrackAsVocalsEvents)
-                {
-                    callBackState = CallbackState.WaitingForExternalInformation;
-                    NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
-                    callBackState = CallbackState.None;
-                    importTrackAsVocalsEvents = result == NativeMessageBox.Result.Yes;
-                }
+                    if (importTrackAsVocalsEvents)
+                    {
+                        callBackState = CallbackState.WaitingForExternalInformation;
+                        NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
+                        callBackState = CallbackState.None;
+                        importTrackAsVocalsEvents = result == NativeMessageBox.Result.Yes;
+                    }
 #endif
                     if (importTrackAsVocalsEvents)
                     {
@@ -647,8 +647,8 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
 
-            // Process forced hopo or forced strum
-            {
+                // Process forced hopo or forced strum
+                {
                     int flagKey = difficultyStartRange + 5;
                     GuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in EventProcessParams eventProcessParams) =>
                     {
@@ -702,8 +702,8 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
 
-            // Process forced hopo or forced strum
-            {
+                // Process forced hopo or forced strum
+                {
                     int flagKey = difficultyStartRange + 7;
                     GhlGuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in EventProcessParams eventProcessParams) =>
                     {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -208,39 +208,46 @@ namespace MoonscraperChartEditor.Song.IO
                 Debug.Log("Found midi track " + trackName.Text);
 
                 string trackNameKey = trackName.Text.ToUpper();
-                if (trackNameKey == MidIOHelper.EVENTS_TRACK)
+                if (c_trackExcludesMap.ContainsKey(trackNameKey))
                 {
-                    ReadSongGlobalEvents(midi.Events[i], song);
+                    continue;
                 }
-                else if (!c_trackExcludesMap.ContainsKey(trackNameKey))
-                {
-                    bool importTrackAsVocalsEvents = trackNameKey == MidIOHelper.VOCALS_TRACK;
 
-#if !UNITY_EDITOR
-                    if (importTrackAsVocalsEvents)
-                    {
-                        callBackState = CallbackState.WaitingForExternalInformation;
-                        NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
-                        callBackState = CallbackState.None;
-                        importTrackAsVocalsEvents = result == NativeMessageBox.Result.Yes;
-                    }
-#endif
-                    if (importTrackAsVocalsEvents)
-                    {
-                        Debug.Log("Loading lyrics from Vocals track");
-                        ReadTextEventsIntoGlobalEventsAsLyrics(midi.Events[i], song);
-                    }
-                    else
-                    {
-                        Song.Instrument instrument;
-                        if (!c_trackNameToInstrumentMap.TryGetValue(trackNameKey, out instrument))
+                switch (trackNameKey)
+                {
+                    case (MidIOHelper.EVENTS_TRACK):
                         {
-                            instrument = Song.Instrument.Unrecognised;
+                            ReadSongGlobalEvents(midi.Events[i], song);
+                            break;
                         }
 
-                        Debug.LogFormat("Loading midi track {0}", instrument);
-                        ReadNotes(midi.Events[i], song, instrument);
-                    }
+                    case (MidIOHelper.VOCALS_TRACK):
+                        {
+#if !UNITY_EDITOR
+                            callBackState = CallbackState.WaitingForExternalInformation;
+                            NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
+                            callBackState = CallbackState.None;
+                            if (result == NativeMessageBox.Result.Yes)
+#endif
+                            {
+                                Debug.Log("Loading lyrics from Vocals track");
+                                ReadTextEventsIntoGlobalEventsAsLyrics(midi.Events[i], song);
+                            }
+                            break;
+                        }
+
+                    default:
+                        {
+                            Song.Instrument instrument;
+                            if (!c_trackNameToInstrumentMap.TryGetValue(trackNameKey, out instrument))
+                            {
+                                instrument = Song.Instrument.Unrecognised;
+                            }
+
+                            Debug.LogFormat("Loading midi track {0}", instrument);
+                            ReadNotes(midi.Events[i], song, instrument);
+                            break;
+                        }
                 }
             }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -888,6 +888,12 @@ namespace MoonscraperChartEditor.Song.IO
             for (int i = index; i < index + length; ++i)
             {
                 Note note = chart.notes[i];
+                if (!note.IsAllowedToBeType(noteType))
+                {
+                    Debug.LogWarning($"Attempted to set a note as a type it is not allowed to be.\nInstrument: {instrument}, new type: {noteType}, current type: {note.type}, tick: {note.tick}, is open note: {note.IsOpenNote()} natural HOPO: {note.isNaturalHopo}, forceable: {!note.cannotBeForced}");
+                    continue;
+                }
+
                 flags = note.GetFlagsToSetType(noteType);
                 firstInChord = lastChordTick != note.tick;
                 perNote = ((flags & Note.PER_NOTE_FLAGS) != 0) && ((flags & ~Note.PER_NOTE_FLAGS) == 0);
@@ -904,7 +910,6 @@ namespace MoonscraperChartEditor.Song.IO
 
                 lastChordTick = note.tick;
 
-                // TODO: Open notes marked as tap notes will make this assert fail
                 Debug.Assert(note.type == noteType);
             }
         }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -849,6 +849,20 @@ namespace MoonscraperChartEditor.Song.IO
             });
         }
 
+        static void ProcessNoteOnEventAsModifier(in NoteProcessParams noteProcessParams, Note.NoteType noteType)
+        {
+            var flagEvent = noteProcessParams.noteEvent;
+
+            // Delay the actual processing once all the notes are actually in
+            foreach (Song.Difficulty diff in EnumX<Song.Difficulty>.Values)
+            {
+                noteProcessParams.forceNotesProcessesList.Add((in NoteProcessParams processParams) =>
+                {
+                    ProcessNoteOnEventAsModifierPostDelay(processParams, flagEvent, diff, noteType);
+                });
+            }
+        }
+
         static void ProcessNoteOnEventAsModifierPostDelay(in NoteProcessParams noteProcessParams, NoteOnEvent noteEvent, Song.Difficulty difficulty, Note.NoteType noteType)
         {
             var song = noteProcessParams.song;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -882,6 +882,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             uint lastChordTick = uint.MaxValue;
             bool firstInChord = true;
+            bool perNote = false;
             Note.Flags flags = Note.Flags.None;
 
             for (int i = index; i < index + length; ++i)
@@ -889,12 +890,13 @@ namespace MoonscraperChartEditor.Song.IO
                 Note note = chart.notes[i];
                 flags = note.GetFlagsToSetType(noteType);
                 firstInChord = lastChordTick != note.tick;
+                perNote = ((flags & Note.PER_NOTE_FLAGS) != 0) && ((flags & ~Note.PER_NOTE_FLAGS) == 0);
 
                 // Only set flags once in a chord, except when there are per-note flags
-                if (firstInChord || (flags & Note.PER_NOTE_FLAGS) != 0)
+                if (firstInChord || perNote)
                 {
                     note.flags = flags;
-                    if (firstInChord)
+                    if (firstInChord && !perNote)
                     {
                         note.ApplyFlagsToChord();
                     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -416,6 +416,12 @@ namespace MoonscraperChartEditor.Song.IO
             else
                 unrecognised.UpdateCache();
 
+            // Apply forcing events
+            foreach (var process in processParams.forceNotesProcessesList)
+            {
+                process(processParams);
+            }
+
             // Apply tap and open note events
             Chart[] chartsOfInstrument;
 
@@ -527,12 +533,6 @@ namespace MoonscraperChartEditor.Song.IO
                             notes[k].guitarFret = LoadDrumNoteToGuitarNote(notes[k].guitarFret);
                     }
                 }
-            }
-
-            // Apply forcing events
-            foreach (var process in processParams.forceNotesProcessesList)
-            {
-                process(processParams);
             }
 
             foreach (var flagEvent in proDrumsNotesList)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -61,6 +61,9 @@ namespace MoonscraperChartEditor.Song.IO
         { MidIOHelper.STARPOWER_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsStarpower(eventProcessParams);
         }},
+        { MidIOHelper.TAP_NOTE, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsModifier(eventProcessParams, Note.NoteType.Tap);
+        }},
         { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
         }},
@@ -70,6 +73,9 @@ namespace MoonscraperChartEditor.Song.IO
     {
         { MidIOHelper.STARPOWER_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsStarpower(eventProcessParams);
+        }},
+        { MidIOHelper.TAP_NOTE, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsModifier(eventProcessParams, Note.NoteType.Tap);
         }},
         { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -910,7 +910,10 @@ namespace MoonscraperChartEditor.Song.IO
 
                 lastChordTick = note.tick;
 
-                Debug.Assert(note.type == noteType);
+                Debug.Assert(
+                    note.type == noteType,
+                    $"Failed to set note as note type {noteType}.\nInstrument: {instrument}, new type: {noteType}, actual type: {note.type}, tick: {note.tick}, is open note: {note.IsOpenNote()} natural HOPO: {note.isNaturalHopo}, forceable: {!note.cannotBeForced}"
+                );
             }
         }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -58,7 +58,9 @@ namespace MoonscraperChartEditor.Song.IO
         // These dictionaries map the NoteNumber of each midi note event to a specific function of how to process them
         static readonly Dictionary<int, EventProcessFn> GuitarMidiNoteNumberToProcessFnMap = new Dictionary<int, EventProcessFn>()
     {
-        { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
+        { MidIOHelper.STARPOWER_NOTE, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams);
+        }},
         { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
         }},
@@ -66,7 +68,9 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly Dictionary<int, EventProcessFn> GhlGuitarMidiNoteNumberToProcessFnMap = new Dictionary<int, EventProcessFn>()
     {
-        { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
+        { MidIOHelper.STARPOWER_NOTE, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams);
+        }},
         { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
         }},
@@ -74,7 +78,9 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly Dictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap = new Dictionary<int, EventProcessFn>()
     {
-        { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
+        { MidIOHelper.STARPOWER_NOTE, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams);
+        }},
         { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
             ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
         }},
@@ -82,11 +88,21 @@ namespace MoonscraperChartEditor.Song.IO
             ProcessNoteOnEventAsNote(eventProcessParams, Song.Difficulty.Expert, (int)Note.DrumPad.Kick, Note.Flags.InstrumentPlus);
         }},
 
-        { MidIOHelper.STARPOWER_DRUM_FILL_0, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_1, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_2, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_3, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_4, ProcessNoteOnEventAsDrumFill },
+        { MidIOHelper.STARPOWER_DRUM_FILL_0, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams, Starpower.Flags.ProDrums_Activation);
+        }},
+        { MidIOHelper.STARPOWER_DRUM_FILL_1, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams, Starpower.Flags.ProDrums_Activation);
+        }},
+        { MidIOHelper.STARPOWER_DRUM_FILL_2, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams, Starpower.Flags.ProDrums_Activation);
+        }},
+        { MidIOHelper.STARPOWER_DRUM_FILL_3, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams, Starpower.Flags.ProDrums_Activation);
+        }},
+        { MidIOHelper.STARPOWER_DRUM_FILL_4, (in EventProcessParams eventProcessParams) => {
+            ProcessNoteOnEventAsStarpower(eventProcessParams, Starpower.Flags.ProDrums_Activation);
+        }},
     };
 
         static MidReader()
@@ -817,7 +833,7 @@ namespace MoonscraperChartEditor.Song.IO
             chart.Add(newNote, false);
         }
 
-        static void ProcessNoteOnEventAsStarpower(in EventProcessParams eventProcessParams)
+        static void ProcessNoteOnEventAsStarpower(in EventProcessParams eventProcessParams, Starpower.Flags flags = Starpower.Flags.None)
         {
             var noteEvent = eventProcessParams.midiEvent as NoteOnEvent;
             Debug.Assert(noteEvent != null, $"Wrong note event type passed to ProcessNoteOnEventAsStarpower. Expected: {typeof(NoteOnEvent)}, Actual: {eventProcessParams.midiEvent.GetType()}");
@@ -829,23 +845,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             foreach (Song.Difficulty diff in EnumX<Song.Difficulty>.Values)
             {
-                song.GetChart(instrument, diff).Add(new Starpower(tick, sus), false);
-            }
-        }
-
-        static void ProcessNoteOnEventAsDrumFill(in EventProcessParams eventProcessParams)
-        {
-            var noteEvent = eventProcessParams.midiEvent as NoteOnEvent;
-            Debug.Assert(noteEvent != null, $"Wrong note event type passed to ProcessNoteOnEventAsDrumFill. Expected: {typeof(NoteOnEvent)}, Actual: {eventProcessParams.midiEvent.GetType()}");
-            var song = eventProcessParams.song;
-            var instrument = eventProcessParams.instrument;
-
-            var tick = (uint)noteEvent.AbsoluteTime;
-            var sus = CalculateSustainLength(song, noteEvent);
-
-            foreach (Song.Difficulty diff in EnumX<Song.Difficulty>.Values)
-            {
-                song.GetChart(instrument, diff).Add(new Starpower(tick, sus, Starpower.Flags.ProDrums_Activation), false);
+                song.GetChart(instrument, diff).Add(new Starpower(tick, sus, flags), false);
             }
         }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -631,14 +631,14 @@ namespace MoonscraperChartEditor.Song.IO
                     int flagKey = difficultyStartRange + 5;
                     GuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in NoteProcessParams noteProcessParams) =>
                     {
-                        ProcessNoteOnEventAsForcedType(noteProcessParams, difficulty, Note.NoteType.Hopo);
+                        ProcessNoteOnEventAsModifier(noteProcessParams, difficulty, Note.NoteType.Hopo);
                     });
                 }
                 {
                     int flagKey = difficultyStartRange + 6;
                     GuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in NoteProcessParams noteProcessParams) =>
                     {
-                        ProcessNoteOnEventAsForcedType(noteProcessParams, difficulty, Note.NoteType.Strum);
+                        ProcessNoteOnEventAsModifier(noteProcessParams, difficulty, Note.NoteType.Strum);
                     });
                 }
             };
@@ -689,14 +689,14 @@ namespace MoonscraperChartEditor.Song.IO
                     int flagKey = difficultyStartRange + 7;
                     GhlGuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in NoteProcessParams noteProcessParams) =>
                     {
-                        ProcessNoteOnEventAsForcedType(noteProcessParams, difficulty, Note.NoteType.Hopo);
+                        ProcessNoteOnEventAsModifier(noteProcessParams, difficulty, Note.NoteType.Hopo);
                     });
                 }
                 {
                     int flagKey = difficultyStartRange + 8;
                     GhlGuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in NoteProcessParams noteProcessParams) =>
                     {
-                        ProcessNoteOnEventAsForcedType(noteProcessParams, difficulty, Note.NoteType.Strum);
+                        ProcessNoteOnEventAsModifier(noteProcessParams, difficulty, Note.NoteType.Strum);
                     });
                 }
             };
@@ -838,18 +838,18 @@ namespace MoonscraperChartEditor.Song.IO
             }
         }
 
-        static void ProcessNoteOnEventAsForcedType(in NoteProcessParams noteProcessParams, Song.Difficulty difficulty, Note.NoteType noteType)
+        static void ProcessNoteOnEventAsModifier(in NoteProcessParams noteProcessParams, Song.Difficulty difficulty, Note.NoteType noteType)
         {
             var flagEvent = noteProcessParams.noteEvent;
 
             // Delay the actual processing once all the notes are actually in
             noteProcessParams.forceNotesProcessesList.Add((in NoteProcessParams processParams) =>
             {
-                ProcessNoteOnEventAsForcedTypePostDelay(processParams, flagEvent, difficulty, noteType);
+                ProcessNoteOnEventAsModifierPostDelay(processParams, flagEvent, difficulty, noteType);
             });
         }
 
-        static void ProcessNoteOnEventAsForcedTypePostDelay(in NoteProcessParams noteProcessParams, NoteOnEvent noteEvent, Song.Difficulty difficulty, Note.NoteType noteType)
+        static void ProcessNoteOnEventAsModifierPostDelay(in NoteProcessParams noteProcessParams, NoteOnEvent noteEvent, Song.Difficulty difficulty, Note.NoteType noteType)
         {
             var song = noteProcessParams.song;
             var instrument = noteProcessParams.instrument;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -527,10 +527,20 @@ namespace MoonscraperChartEditor.Song.IO
                     SongObjectHelper.GetRange(notes, tick, tick + endPos, out index, out length);
                     for (int k = index; k < index + length; ++k)
                     {
-                        notes[k].guitarFret = Note.GuitarFret.Open;
+                        switch (gameMode)
+                        {
+                            case (Chart.GameMode.Guitar):
+                                notes[k].guitarFret = Note.GuitarFret.Open;
+                                break;
 
-                        if (gameMode == Chart.GameMode.Drums)
-                            notes[k].guitarFret = LoadDrumNoteToGuitarNote(notes[k].guitarFret);
+                            case (Chart.GameMode.GHLGuitar):
+                                notes[k].ghliveGuitarFret = Note.GHLiveGuitarFret.Open;
+                                break;
+
+                            case (Chart.GameMode.Drums):
+                                notes[k].guitarFret = LoadDrumNoteToGuitarNote(notes[k].guitarFret);
+                                break;
+                        }
                     }
                 }
             }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Song.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Song.cs
@@ -212,6 +212,28 @@ namespace MoonscraperChartEditor.Song
             }
         }
 
+        public bool ChartExistsForInstrument(Instrument instrument)
+        {
+            try
+            {
+                int startIndex = (int)instrument * EnumX<Difficulty>.Count;
+                for (int i = startIndex; i < startIndex + EnumX<Difficulty>.Count; i++)
+                {
+                    if (charts[i].chartObjects.Count != 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+                return false;
+            }
+        }
+
         /// <summary>
         /// Converts a time value into a tick position value. May be inaccurate due to interger rounding.
         /// </summary>


### PR DESCRIPTION
this was supposed to be a smaller PR, but there's too many things to fix lol

Feature summary:

- Added legacy Star Power fixup (closes issue #68)
- Added note-based tap note parsing
- Added support for `[ENHANCED_OPENS]` and `[ENABLE_CHART_DYNAMICS]`
- Allow the `T1 GEMS` and `PART REAL_DRUMS_PS` tracks (closes issue #38)
- Added `VENUE` track to track exclusion list
- Fixed GHL open note SysEx events turning notes into White 3 notes instead of open notes