### PR TITLE
Initial .mid parser cleanups

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -53,6 +53,30 @@ namespace MoonscraperChartEditor.Song.IO
         public const byte VELOCITY_GHOST = 1;         // fof/ps
 
         // Lookup tables
+        public static readonly Dictionary<Song.Difficulty, int> GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
+    {
+        { Song.Difficulty.Easy, 60 },
+        { Song.Difficulty.Medium, 72 },
+        { Song.Difficulty.Hard, 84 },
+        { Song.Difficulty.Expert, 96 }
+    };
+
+        public static readonly Dictionary<Song.Difficulty, int> GHL_GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
+    {
+        { Song.Difficulty.Easy, 58 },
+        { Song.Difficulty.Medium, 70 },
+        { Song.Difficulty.Hard, 82 },
+        { Song.Difficulty.Expert, 94 }
+    };
+
+        public static readonly Dictionary<Song.Difficulty, int> DRUMS_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
+    {
+        { Song.Difficulty.Easy, 60 },
+        { Song.Difficulty.Medium, 72 },
+        { Song.Difficulty.Hard, 84 },
+        { Song.Difficulty.Expert, 96 }
+    };
+
         // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring
         public static readonly Dictionary<Note.DrumPad, int> PAD_TO_CYMBAL_LOOKUP = new Dictionary<Note.DrumPad, int>()
     {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -9,7 +9,8 @@ namespace MoonscraperChartEditor.Song.IO
 {
     public static class MidIOHelper
     {
-        public const string EVENTS_TRACK = "EVENTS";           // Sections
+        // Track names
+        public const string EVENTS_TRACK = "EVENTS";
         public const string GUITAR_TRACK = "PART GUITAR";
         public const string GUITAR_COOP_TRACK = "PART GUITAR COOP";
         public const string BASS_TRACK = "PART BASS";
@@ -20,34 +21,38 @@ namespace MoonscraperChartEditor.Song.IO
         public const string GHL_BASS_TRACK = "PART BASS GHL";
         public const string VOCALS_TRACK = "PART VOCALS";
 
-        public const string LYRIC_EVENT_PREFIX = LyricHelper.LYRIC_EVENT_PREFIX;
-        public const byte SOLO_NOTE = 0x67;                 // 103, http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
-        public const byte STARPOWER_NOTE = 0x74;            // 116, http://docs.c3universe.com/rbndocs/index.php?title=Overdrive_and_Big_Rock_Endings
+        // Note numbers
+        public const byte DOUBLE_KICK_NOTE = 95;
+        public const byte SOLO_NOTE = 103;                 // http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
+        public const byte LYRICS_PHRASE_1 = 105;           // http://docs.c3universe.com/rbndocs/index.php?title=Vocal_Authoring
+        public const byte LYRICS_PHRASE_2 = 106;           // Rock Band charts before RB3 mark phrases using this note as well
+        public const byte FLAM_MARKER = 109;
+        public const byte STARPOWER_NOTE = 116;            // http://docs.c3universe.com/rbndocs/index.php?title=Overdrive_and_Big_Rock_Endings
 
-        // 120 - 124 http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
+        // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
         public const byte STARPOWER_DRUM_FILL_0 = 120;
         public const byte STARPOWER_DRUM_FILL_1 = 121;
         public const byte STARPOWER_DRUM_FILL_2 = 122;
         public const byte STARPOWER_DRUM_FILL_3 = 123;
         public const byte STARPOWER_DRUM_FILL_4 = 124;
 
-        public const string SoloEventText = "solo";
-        public const string SoloEndEventText = "soloend";
-        public const int DOUBLE_KICK_NOTE = 95;
-        public const byte FLAM_MARKER = 0x6d;                  // 109
+        // Text events
+        public const string SOLO_EVENT_TEXT = "solo";
+        public const string SOLO_END_EVENT_TEXT = "soloend";
 
-        public const int PhraseMarker = 105; // http://docs.c3universe.com/rbndocs/index.php?title=Vocal_Authoring
-        public const int PhraseMarker2 = 106; // Rock Band charts before RB3 mark phrases using this note as well
-        public const string PhraseStartText = LyricHelper.PhraseStartText;
-        public const string PhraseEndText = LyricHelper.PhraseEndText;
+        public const string LYRIC_EVENT_PREFIX = LyricHelper.LYRIC_EVENT_PREFIX;
+        public const string LYRICS_PHRASE_START_TEXT = LyricHelper.PhraseStartText;
+        public const string LYRICS_PHRASE_END_TEXT = LyricHelper.PhraseEndText;
 
-        public const string Rb2SectionPrefix = "section ";
-        public const string Rb3SectionPrefix = "prc_";
+        public const string SECTION_PREFIX_RB2 = "section ";
+        public const string SECTION_PREFIX_RB3 = "prc_";
 
-        public const byte VELOCITY = 0x64;              // 100
-        public const byte VELOCITY_ACCENT = 0x7f;       // 127, fof/ps
-        public const byte VELOCITY_GHOST = 0x1;         // 1, fof/ps
+        // Note velocities
+        public const byte VELOCITY = 100;             // default note velocity for exporting
+        public const byte VELOCITY_ACCENT = 127;      // fof/ps
+        public const byte VELOCITY_GHOST = 1;         // fof/ps
 
+        // Lookup tables
         // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring
         public static readonly Dictionary<Note.DrumPad, int> PAD_TO_CYMBAL_LOOKUP = new Dictionary<Note.DrumPad, int>()
     {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -898,8 +898,6 @@ namespace MoonscraperChartEditor.Song.IO
             uint tick = (uint)noteEvent.AbsoluteTime;
             uint endPos = (uint)(noteEvent.OffEvent.AbsoluteTime - tick);
             --endPos;
-
-            var flagEvent = noteEvent;
 
             foreach (Song.Difficulty difficulty in EnumX<Song.Difficulty>.Values)
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -340,21 +340,19 @@ namespace MoonscraperChartEditor.Song.IO
             var noteProcessDict = GetNoteProcessDict(gameMode);
 
             if (instrument == Song.Instrument.Unrecognised)
+            {
+                var text = track[0] as TextEvent;
+                if (text != null)
+                    unrecognised.name = text.Text;
                 song.unrecognisedCharts.Add(unrecognised);
+            }
 
             // Load all the notes
-            for (int i = 0; i < track.Count; i++)
+            for (int i = 1; i < track.Count; i++)
             {
                 var text = track[i] as TextEvent;
                 if (text != null)
                 {
-                    if (i == 0)
-                    {
-                        if (instrument == Song.Instrument.Unrecognised)
-                            unrecognised.name = text.Text;
-                        continue;           // We don't want the first event because that is the name of the track
-                    }
-
                     var tick = (uint)text.AbsoluteTime;
                     var eventName = text.Text;
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -865,7 +865,7 @@ namespace MoonscraperChartEditor.Song.IO
         static void ProcessNoteOnEventAsEvent(EventProcessParams eventProcessParams, string eventStartText, string eventEndText)
         {
             var noteEvent = eventProcessParams.midiEvent as NoteOnEvent;
-            Debug.Assert(noteEvent != null, $"Wrong note event type passed to ProcessNoteOnEventAsEvent. Expected: {typeof(NoteOnEvent)}, Actual: {eventProcessParams.midiEvent.GetType()}");
+            Debug.Assert(noteEvent != null, $"Wrong note event type passed to {nameof(ProcessNoteOnEventAsEvent)}. Expected: {typeof(NoteOnEvent)}, Actual: {eventProcessParams.midiEvent.GetType()}");
             var song = eventProcessParams.song;
             var instrument = eventProcessParams.instrument;
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -534,8 +534,16 @@ namespace MoonscraperChartEditor.Song.IO
                     SongObjectHelper.GetRange(notes, tick, tick + endPos, out index, out length);
                     for (int k = index; k < index + length; ++k)
                     {
-                        if (gameMode != Chart.GameMode.Drums)
-                            notes[k].guitarFret = Note.GuitarFret.Open;
+                        switch (gameMode)
+                        {
+                            case Chart.GameMode.Guitar:
+                                notes[k].guitarFret = Note.GuitarFret.Open;
+                                break;
+                            // Usually not used, but in the case that it is, it should work properly
+                            case Chart.GameMode.GHLGuitar:
+                                notes[k].ghliveGuitarFret = Note.GHLiveGuitarFret.Open;
+                                break;
+                        }
                     }
                 }
             }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -338,6 +338,7 @@ namespace MoonscraperChartEditor.Song.IO
         {
             if (track == null || track.Count < 1)
             {
+                Debug.LogError($"Attempted to load null or empty track.");
                 return;
             }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -161,30 +161,31 @@ namespace MoonscraperChartEditor.Song.IO
                 Debug.Log("Found midi track " + trackName.Text);
 
                 string trackNameKey = trackName.Text.ToUpper();
-                if (trackNameKey == MidIOHelper.EVENTS_TRACK)
+                if (c_trackExcludesMap.ContainsKey(trackNameKey))
                 {
-                    ReadSongGlobalEvents(midi.Events[i], song);
+                    continue;
                 }
-                else if (!c_trackExcludesMap.ContainsKey(trackNameKey))
-                {
-                    bool importTrackAsVocalsEvents = trackNameKey == MidIOHelper.VOCALS_TRACK;
 
+                switch (trackNameKey)
+                {
+                    case MidIOHelper.EVENTS_TRACK:
+                        ReadSongGlobalEvents(midi.Events[i], song);
+                        break;
+
+                    case MidIOHelper.VOCALS_TRACK:
 #if !UNITY_EDITOR
-                    if (importTrackAsVocalsEvents)
-                    {
                         callBackState = CallbackState.WaitingForExternalInformation;
                         NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
                         callBackState = CallbackState.None;
-                        importTrackAsVocalsEvents = result == NativeMessageBox.Result.Yes;
-                    }
+                        if (result == NativeMessageBox.Result.Yes)
 #endif
-                    if (importTrackAsVocalsEvents)
-                    {
-                        Debug.Log("Loading lyrics from Vocals track");
-                        ReadTextEventsIntoGlobalEventsAsLyrics(midi.Events[i], song);
-                    }
-                    else
-                    {
+                        {
+                            Debug.Log("Loading lyrics from Vocals track");
+                            ReadTextEventsIntoGlobalEventsAsLyrics(midi.Events[i], song);
+                        }
+                        break;
+
+                    default:
                         Song.Instrument instrument;
                         if (!c_trackNameToInstrumentMap.TryGetValue(trackNameKey, out instrument))
                         {
@@ -193,7 +194,7 @@ namespace MoonscraperChartEditor.Song.IO
 
                         Debug.LogFormat("Loading midi track {0}", instrument);
                         ReadNotes(midi.Events[i], song, instrument);
-                    }
+                        break;
                 }
             }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -591,14 +591,8 @@ namespace MoonscraperChartEditor.Song.IO
             return GuitarMidiNoteNumberToProcessFnMap;
         }
 
-        delegate void BuildPerDifficultyFn(int difficultyStartRange, Song.Difficulty difficulty);
         static void BuildGuitarMidiNoteNumberToProcessFnDict()
         {
-            const int EasyStartRange = 60;
-            const int MediumStartRange = 72;
-            const int HardStartRange = 84;
-            const int ExpertStartRange = 96;
-
             Dictionary<Note.GuitarFret, int> FretToMidiKey = new Dictionary<Note.GuitarFret, int>()
         {
             // { Note.GuitarFret.Open, 0 }, // Handled by sysex event
@@ -609,8 +603,9 @@ namespace MoonscraperChartEditor.Song.IO
             { Note.GuitarFret.Orange, 4 },
         };
 
-            BuildPerDifficultyFn BuildPerDifficulty = (int difficultyStartRange, Song.Difficulty difficulty) =>
+            foreach (var difficulty in EnumX<Song.Difficulty>.Values)
             {
+                int difficultyStartRange = MidIOHelper.GUITAR_DIFF_START_LOOKUP[difficulty];
                 foreach (var guitarFret in EnumX<Note.GuitarFret>.Values)
                 {
                     int fretOffset;
@@ -642,20 +637,10 @@ namespace MoonscraperChartEditor.Song.IO
                     });
                 }
             };
-
-            BuildPerDifficulty(EasyStartRange, Song.Difficulty.Easy);
-            BuildPerDifficulty(MediumStartRange, Song.Difficulty.Medium);
-            BuildPerDifficulty(HardStartRange, Song.Difficulty.Hard);
-            BuildPerDifficulty(ExpertStartRange, Song.Difficulty.Expert);
         }
 
         static void BuildGhlGuitarMidiNoteNumberToProcessFnDict()
         {
-            const int EasyStartRange = 58;
-            const int MediumStartRange = 70;
-            const int HardStartRange = 82;
-            const int ExpertStartRange = 94;
-
             Dictionary<Note.GHLiveGuitarFret, int> FretToMidiKey = new Dictionary<Note.GHLiveGuitarFret, int>()
         {
             { Note.GHLiveGuitarFret.Open, 0 },
@@ -667,8 +652,9 @@ namespace MoonscraperChartEditor.Song.IO
             { Note.GHLiveGuitarFret.Black3, 6 },
         };
 
-            BuildPerDifficultyFn BuildPerDifficulty = (int difficultyStartRange, Song.Difficulty difficulty) =>
+            foreach (var difficulty in EnumX<Song.Difficulty>.Values)
             {
+                int difficultyStartRange = MidIOHelper.GHL_GUITAR_DIFF_START_LOOKUP[difficulty];
                 foreach (var guitarFret in EnumX<Note.GHLiveGuitarFret>.Values)
                 {
                     int fretOffset;
@@ -700,20 +686,10 @@ namespace MoonscraperChartEditor.Song.IO
                     });
                 }
             };
-
-            BuildPerDifficulty(EasyStartRange, Song.Difficulty.Easy);
-            BuildPerDifficulty(MediumStartRange, Song.Difficulty.Medium);
-            BuildPerDifficulty(HardStartRange, Song.Difficulty.Hard);
-            BuildPerDifficulty(ExpertStartRange, Song.Difficulty.Expert);
         }
 
         static void BuildDrumsMidiNoteNumberToProcessFnDict()
         {
-            const int EasyStartRange = 60;
-            const int MediumStartRange = 72;
-            const int HardStartRange = 84;
-            const int ExpertStartRange = 96;
-
             Dictionary<Note.DrumPad, int> DrumPadToMidiKey = new Dictionary<Note.DrumPad, int>()
         {
             { Note.DrumPad.Kick, 0 },
@@ -731,8 +707,9 @@ namespace MoonscraperChartEditor.Song.IO
             { Note.DrumPad.Orange, Note.Flags.ProDrums_Cymbal },
         };
 
-            BuildPerDifficultyFn BuildPerDifficulty = (int difficultyStartRange, Song.Difficulty difficulty) =>
+            foreach (var difficulty in EnumX<Song.Difficulty>.Values)
             {
+                int difficultyStartRange = MidIOHelper.DRUMS_DIFF_START_LOOKUP[difficulty];
                 foreach (var pad in EnumX<Note.DrumPad>.Values)
                 {
                     int padOffset;
@@ -750,11 +727,6 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
             };
-
-            BuildPerDifficulty(EasyStartRange, Song.Difficulty.Easy);
-            BuildPerDifficulty(MediumStartRange, Song.Difficulty.Medium);
-            BuildPerDifficulty(HardStartRange, Song.Difficulty.Hard);
-            BuildPerDifficulty(ExpertStartRange, Song.Difficulty.Expert);
 
             foreach (var keyVal in MidIOHelper.PAD_TO_CYMBAL_LOOKUP)
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -521,10 +521,8 @@ namespace MoonscraperChartEditor.Song.IO
                     SongObjectHelper.GetRange(notes, tick, tick + endPos, out index, out length);
                     for (int k = index; k < index + length; ++k)
                     {
-                        notes[k].guitarFret = Note.GuitarFret.Open;
-
-                        if (gameMode == Chart.GameMode.Drums)
-                            notes[k].guitarFret = LoadDrumNoteToGuitarNote(notes[k].guitarFret);
+                        if (gameMode != Chart.GameMode.Drums)
+                            notes[k].guitarFret = Note.GuitarFret.Open;
                     }
                 }
             }
@@ -962,16 +960,6 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
             }
-        }
-
-        static Note.GuitarFret LoadDrumNoteToGuitarNote(Note.GuitarFret fret_type)
-        {
-            if (fret_type == Note.GuitarFret.Open)
-                return Note.GuitarFret.Orange;
-            else if (fret_type == Note.GuitarFret.Green)
-                return Note.GuitarFret.Open;
-            else
-                return fret_type - 1;
         }
     }
 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -855,8 +855,8 @@ namespace MoonscraperChartEditor.Song.IO
         {
             uint tick = (uint)noteEvent.AbsoluteTime;
             var sus = (uint)(noteEvent.OffEvent.AbsoluteTime - tick);
-            int rbSustainFixLength = (int)(64 * song.resolution / SongConfig.STANDARD_BEAT_RESOLUTION);
-            if (sus <= rbSustainFixLength)
+            int susCutoff = (int)(song.resolution / 3); // 1/12th note
+            if (sus <= susCutoff)
                 sus = 0;
 
             return sus;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -170,13 +170,13 @@ namespace MoonscraperChartEditor.Song.IO
                     bool importTrackAsVocalsEvents = trackNameKey == MidIOHelper.VOCALS_TRACK;
 
 #if !UNITY_EDITOR
-                if (importTrackAsVocalsEvents)
-                {
-                    callBackState = CallbackState.WaitingForExternalInformation;
-                    NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
-                    callBackState = CallbackState.None;
-                    importTrackAsVocalsEvents = result == NativeMessageBox.Result.Yes;
-                }
+                    if (importTrackAsVocalsEvents)
+                    {
+                        callBackState = CallbackState.WaitingForExternalInformation;
+                        NativeMessageBox.Result result = NativeMessageBox.Show("A vocals track was found in the file. Would you like to import the text events as global lyrics and phrase events?", "Vocals Track Found", NativeMessageBox.Type.YesNo, null);
+                        callBackState = CallbackState.None;
+                        importTrackAsVocalsEvents = result == NativeMessageBox.Result.Yes;
+                    }
 #endif
                     if (importTrackAsVocalsEvents)
                     {
@@ -621,8 +621,8 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
 
-            // Process forced hopo or forced strum
-            {
+                // Process forced hopo or forced strum
+                {
                     int flagKey = difficultyStartRange + 5;
                     GuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in EventProcessParams eventProcessParams) =>
                     {
@@ -670,8 +670,8 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
 
-            // Process forced hopo or forced strum
-            {
+                // Process forced hopo or forced strum
+                {
                     int flagKey = difficultyStartRange + 7;
                     GhlGuitarMidiNoteNumberToProcessFnMap.Add(flagKey, (in EventProcessParams eventProcessParams) =>
                     {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -543,6 +543,9 @@ namespace MoonscraperChartEditor.Song.IO
                                 case Chart.GameMode.GHLGuitar:
                                     notes[k].ghliveGuitarFret = Note.GHLiveGuitarFret.Open;
                                     break;
+                                default:
+                                    Debug.Assert(false, $"Unhandled game mode for open note SysEx event: {gameMode}");
+                                    break;
                             }
                         }
                     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -60,7 +60,7 @@ namespace MoonscraperChartEditor.Song.IO
     {
         { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
         { MidIOHelper.SOLO_NOTE, (in NoteProcessParams noteProcessParams) => {
-            ProcessNoteOnEventAsEvent(noteProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
+            ProcessNoteOnEventAsEvent(noteProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
         }},
     };
 
@@ -68,7 +68,7 @@ namespace MoonscraperChartEditor.Song.IO
     {
         { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
         { MidIOHelper.SOLO_NOTE, (in NoteProcessParams noteProcessParams) => {
-            ProcessNoteOnEventAsEvent(noteProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
+            ProcessNoteOnEventAsEvent(noteProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
         }},
     };
 
@@ -76,7 +76,7 @@ namespace MoonscraperChartEditor.Song.IO
     {
         { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
         { MidIOHelper.SOLO_NOTE, (in NoteProcessParams noteProcessParams) => {
-            ProcessNoteOnEventAsEvent(noteProcessParams, MidIOHelper.SoloEventText, MidIOHelper.SoloEndEventText);
+            ProcessNoteOnEventAsEvent(noteProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
         }},
         { MidIOHelper.DOUBLE_KICK_NOTE, (in NoteProcessParams noteProcessParams) => {
             ProcessNoteOnEventAsNote(noteProcessParams, Song.Difficulty.Expert, (int)Note.DrumPad.Kick, Note.Flags.InstrumentPlus);
@@ -251,8 +251,8 @@ namespace MoonscraperChartEditor.Song.IO
 
         private static void ReadSongGlobalEvents(IList<MidiEvent> track, Song song)
         {
-            const string rb2SectionPrefix = "[" + MidIOHelper.Rb2SectionPrefix;
-            const string rb3SectionPrefix = "[" + MidIOHelper.Rb3SectionPrefix;
+            const string rb2SectionPrefix = "[" + MidIOHelper.SECTION_PREFIX_RB2;
+            const string rb3SectionPrefix = "[" + MidIOHelper.SECTION_PREFIX_RB3;
 
             for (int i = 1; i < track.Count; ++i)
             {
@@ -308,12 +308,12 @@ namespace MoonscraperChartEditor.Song.IO
 
                 var phrase = track[i] as NoteOnEvent;
                 if (phrase != null && phrase.OffEvent != null &&
-                    (phrase.NoteNumber == MidIOHelper.PhraseMarker || phrase.NoteNumber == MidIOHelper.PhraseMarker2))
+                    (phrase.NoteNumber == MidIOHelper.LYRICS_PHRASE_1 || phrase.NoteNumber == MidIOHelper.LYRICS_PHRASE_2))
                 {
-                    string phraseStartEvent = MidIOHelper.PhraseStartText;
+                    string phraseStartEvent = MidIOHelper.LYRICS_PHRASE_START_TEXT;
                     song.Add(new Event(phraseStartEvent, (uint)phrase.AbsoluteTime), false);
 
-                    string phraseEndEvent = MidIOHelper.PhraseEndText;
+                    string phraseEndEvent = MidIOHelper.LYRICS_PHRASE_END_TEXT;
                     song.Add(new Event(phraseEndEvent, (uint)phrase.OffEvent.AbsoluteTime), false);
                 }
             }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -126,7 +126,7 @@ namespace MoonscraperChartEditor.Song.IO
                 InsertionSort(processParams.out_sortableBytes, bytes);
             }},
 
-            { MidIOHelper.PhraseStartText, (in VocalProcessingParams processParams) => {
+            { MidIOHelper.LYRICS_PHRASE_START_TEXT, (in VocalProcessingParams processParams) => {
 
                 Event phraseStartEvent = processParams.eventList[processParams.eventListIndex];
                 uint phraseEndEventTick = phraseStartEvent.tick;    // Find next phase end or the next phase start, whichever is first. 1 tick away as a backup. 
@@ -134,12 +134,12 @@ namespace MoonscraperChartEditor.Song.IO
                 for (int i = processParams.eventListIndex + 1; i < processParams.eventList.Count; ++i)
                 {
                     Event nextEvent = processParams.eventList[i];
-                    if (nextEvent.title.StartsWith(MidIOHelper.PhraseEndText))
+                    if (nextEvent.title.StartsWith(MidIOHelper.LYRICS_PHRASE_END_TEXT))
                     {
                         phraseEndEventTick = nextEvent.tick;
                         break;
                     }
-                    else if(nextEvent.title.StartsWith(MidIOHelper.PhraseStartText))
+                    else if(nextEvent.title.StartsWith(MidIOHelper.LYRICS_PHRASE_START_TEXT))
                     {
                         phraseEndEventTick = nextEvent.tick - 1;
                         break;
@@ -155,13 +155,13 @@ namespace MoonscraperChartEditor.Song.IO
                 Note phraseNote = new Note(phraseStartEvent.tick, 0, phraseEndEventTick - phraseStartEvent.tick);
                 SortableBytes onEvent = null;
                 SortableBytes offEvent = null;
-                GetNoteNumberBytes(MidIOHelper.PhraseMarker, phraseNote, VELOCITY, out onEvent, out offEvent);
+                GetNoteNumberBytes(MidIOHelper.LYRICS_PHRASE_1, phraseNote, VELOCITY, out onEvent, out offEvent);
 
                 InsertionSort(processParams.out_sortableBytes, onEvent);
                 InsertionSort(processParams.out_sortableBytes, offEvent);
             }},
 
-            { MidIOHelper.PhraseEndText, (in VocalProcessingParams processParams) => {
+            { MidIOHelper.LYRICS_PHRASE_END_TEXT, (in VocalProcessingParams processParams) => {
                 // Do nothing, phrase start handles this. Still need to mark it here for it to be excluded from regular events track
             }},
         };
@@ -323,19 +323,19 @@ namespace MoonscraperChartEditor.Song.IO
             VocalProcessingParams vocalProcesingParams = new VocalProcessingParams() { song = song, out_sortableBytes = vocalsEvents };
 
             var rbFormat = exportOptions.midiOptions.rbFormat;
-            string section_id = MidIOHelper.Rb2SectionPrefix;
+            string section_id = MidIOHelper.SECTION_PREFIX_RB2;
 
             switch (rbFormat)
             {
                 case ExportOptions.MidiOptions.RBFormat.RB3:
                     {
-                        section_id = MidIOHelper.Rb3SectionPrefix;
+                        section_id = MidIOHelper.SECTION_PREFIX_RB3;
                         break;
                     }
                 case ExportOptions.MidiOptions.RBFormat.RB2:
                 default:
                     {
-                        section_id = MidIOHelper.Rb2SectionPrefix;
+                        section_id = MidIOHelper.SECTION_PREFIX_RB2;
                         break;
                     }
             }
@@ -648,12 +648,12 @@ namespace MoonscraperChartEditor.Song.IO
                     ChartEvent chartEvent = chartObject as ChartEvent;
                     if (chartEvent != null)     // Text events cannot be split up in the file
                     {
-                        if (soloOnEvent != null && chartEvent.eventName == MidIOHelper.SoloEndEventText)
+                        if (soloOnEvent != null && chartEvent.eventName == MidIOHelper.SOLO_END_EVENT_TEXT)
                         {
                             GetSoloBytes(soloOnEvent, chartEvent.tick, out onEvent, out offEvent);
                             soloOnEvent = null;
                         }
-                        else if (chartEvent.eventName == MidIOHelper.SoloEventText)
+                        else if (chartEvent.eventName == MidIOHelper.SOLO_EVENT_TEXT)
                         {
                             soloOnEvent = chartEvent;
                         }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/SongConfig.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/SongConfig.cs
@@ -9,6 +9,7 @@ namespace MoonscraperChartEditor.Song
         public const uint FULL_STEP = 768;
         public const float RESOLUTIONS_PER_MEASURE = 4.0f;
         public const int FORCED_NOTE_TICK_THRESHOLD = 65;
+        public const int MIDI_SUSTAIN_CUTOFF_THRESHOLD = 64;
         public const int PRO_DRUMS_LANE_COUNT = 4;
     }
 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Misc/SongValidate.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Misc/SongValidate.cs
@@ -230,7 +230,7 @@ public class SongValidate
                         int soloMarkerCount = 0;
                         foreach (ChartEvent ce in chart.events)
                         {
-                            if (ce.eventName == MoonscraperChartEditor.Song.IO.MidIOHelper.SoloEventText)
+                            if (ce.eventName == MoonscraperChartEditor.Song.IO.MidIOHelper.SOLO_EVENT_TEXT)
                             {
                                 ++soloMarkerCount;
 


### PR DESCRIPTION
These changes will make it easier for future changes I have planned.

Summary:
- Tidy up MidIOHelper
  - Reorganize things into categories
  - Rename everything into const case
- Make event processing work with all MIDI event types, and add assertations to ensure the right type is passed to methods
- Add difficulty start index lookups in MidIOHelper and use them in building lookup tables
- Fix some indentation in MidReader
- Ignore SysEx events on drums and unknown tracks
- Use a switch case when checking track names
- Remove unused code in note reading
- Create a constant from the magic number in sustain cutoff calculation
- Assign the name of an unrecognized chart outside of the note loading loop
- Remove an unused variable in ProcessNoteOnEventAsFlagTogglePostDelay
- Fix open note SysEx events on GHL turning the note into White 3 instead of an open note