### PR TITLE
Drums accent/ghost parsing, editing, and basic rendering

### DIFF
--- a/Moonscraper Chart Editor/Assets/Database/InputPropertiesConfig.json
+++ b/Moonscraper Chart Editor/Assets/Database/InputPropertiesConfig.json
@@ -485,6 +485,28 @@
             }
         },
         {
+            "mSChartEditorInputAction": "ToggleNoteAccent",
+            "properties": {
+                "displayName": "Toggle Note Accent",
+                "rebindable": true,
+                "hiddenInLists": false,
+                "anyDirectionAxis": false,
+                "category": 3,
+                "allowSameFrameMultiInput": false
+            }
+        },
+        {
+            "mSChartEditorInputAction": "ToggleNoteGhost",
+            "properties": {
+                "displayName": "Toggle Note Ghost",
+                "rebindable": true,
+                "hiddenInLists": false,
+                "anyDirectionAxis": false,
+                "category": 3,
+                "allowSameFrameMultiInput": false
+            }
+        },
+        {
             "mSChartEditorInputAction": "ToggleStarpowerDrumsFillActivation",
             "properties": {
                 "displayName": "Toggle Starpower Drums Fill Activation",

--- a/Moonscraper Chart Editor/Assets/Database/InputPropertiesConfig.json
+++ b/Moonscraper Chart Editor/Assets/Database/InputPropertiesConfig.json
@@ -265,6 +265,28 @@
             }
         },
         {
+            "mSChartEditorInputAction": "NoteSetAccent",
+            "properties": {
+                "displayName": "Set Note As Accent",
+                "rebindable": false,
+                "hiddenInLists": false,
+                "anyDirectionAxis": false,
+                "category": 1,
+                "allowSameFrameMultiInput": false
+            }
+        },
+        {
+            "mSChartEditorInputAction": "NoteSetGhost",
+            "properties": {
+                "displayName": "Set Note AS Ghost",
+                "rebindable": false,
+                "hiddenInLists": false,
+                "anyDirectionAxis": false,
+                "category": 1,
+                "allowSameFrameMultiInput": false
+            }
+        },
+        {
             "mSChartEditorInputAction": "PlayPause",
             "properties": {
                 "displayName": "Play/Pause",

--- a/Moonscraper Chart Editor/Assets/Database/InputPropertiesConfig.json
+++ b/Moonscraper Chart Editor/Assets/Database/InputPropertiesConfig.json
@@ -268,7 +268,7 @@
             "mSChartEditorInputAction": "NoteSetAccent",
             "properties": {
                 "displayName": "Set Note As Accent",
-                "rebindable": false,
+                "rebindable": true,
                 "hiddenInLists": false,
                 "anyDirectionAxis": false,
                 "category": 1,
@@ -278,8 +278,8 @@
         {
             "mSChartEditorInputAction": "NoteSetGhost",
             "properties": {
-                "displayName": "Set Note AS Ghost",
-                "rebindable": false,
+                "displayName": "Set Note As Ghost",
+                "rebindable": true,
                 "hiddenInLists": false,
                 "anyDirectionAxis": false,
                 "category": 1,

--- a/Moonscraper Chart Editor/Assets/Editor/PopulateInputConfig.cs
+++ b/Moonscraper Chart Editor/Assets/Editor/PopulateInputConfig.cs
@@ -37,6 +37,8 @@ public class PopulateInputConfig : Editor
                 InputConfig inputConfig = new InputConfig();
                 InputConfig.LoadFromFile(filename, inputConfig);
                 inputProperties.shortcutInputs = inputConfig.shortcutInputs;
+
+                Debug.Log("Input properties config loaded successfully");
             }
         }
         if (GUILayout.Button("Save Config To File")) 

--- a/Moonscraper Chart Editor/Assets/Prefabs/UI/Inspectors/Group Select Inspector.prefab
+++ b/Moonscraper Chart Editor/Assets/Prefabs/UI/Inspectors/Group Select Inspector.prefab
@@ -31,7 +31,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -126,7 +126,7 @@ RectTransform:
   m_Children:
   - {fileID: 7838518238970430411}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -343,7 +343,7 @@ RectTransform:
   m_Children:
   - {fileID: 4080964883834491875}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -527,6 +527,311 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Alt Double Kick
+--- !u!1 &3225507680929063253
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8434495684698479768}
+  - component: {fileID: 2017697963257614279}
+  - component: {fileID: 7251998106509305226}
+  - component: {fileID: 8410474288149985642}
+  - component: {fileID: 4030853687519456723}
+  m_Layer: 5
+  m_Name: Set Ghost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8434495684698479768
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3225507680929063253}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1785932095468241976}
+  m_Father: {fileID: 8905959309469288398}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 69.3, y: 20.8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2017697963257614279
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3225507680929063253}
+  m_CullTransparentMesh: 0
+--- !u!114 &7251998106509305226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3225507680929063253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ac572609af7c10646a6327a0bcbf71f8, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &8410474288149985642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3225507680929063253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7251998106509305226}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8905959309039144175}
+        m_MethodName: SetGhost
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4030853687519456723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3225507680929063253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 635727e25c735994fb6f858716ba8247, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  message: 'Shortcut Key: |NoteSetGhost|'
+  offset: {x: 30, y: -7}
+--- !u!1 &4479220371539376820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1785932095468241976}
+  - component: {fileID: 4188152019704040063}
+  - component: {fileID: 2946037632481773566}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1785932095468241976
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4479220371539376820}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8434495684698479768}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4188152019704040063
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4479220371539376820}
+  m_CullTransparentMesh: 0
+--- !u!114 &2946037632481773566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4479220371539376820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 2e4970c185db220408da833322ff835e, type: 3}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Ghost
+--- !u!1 &4538212625170957568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7660918409062388105}
+  - component: {fileID: 4628403795805586360}
+  - component: {fileID: 4384606498740172842}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7660918409062388105
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4538212625170957568}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2155723559591302775}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4628403795805586360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4538212625170957568}
+  m_CullTransparentMesh: 0
+--- !u!114 &4384606498740172842
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4538212625170957568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 2e4970c185db220408da833322ff835e, type: 3}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Accent
 --- !u!1 &5174352183160540178
 GameObject:
   m_ObjectHideFlags: 0
@@ -556,13 +861,153 @@ RectTransform:
   m_Children:
   - {fileID: 8905959309808926942}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 15
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 68.43402, y: 21.8}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7322947784471087719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2155723559591302775}
+  - component: {fileID: 871372635239149084}
+  - component: {fileID: 5663239582614092590}
+  - component: {fileID: 2190134760596699691}
+  - component: {fileID: 1120683048572588063}
+  m_Layer: 5
+  m_Name: Set Accent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2155723559591302775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322947784471087719}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7660918409062388105}
+  m_Father: {fileID: 8905959309469288398}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 69.3, y: 20.8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &871372635239149084
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322947784471087719}
+  m_CullTransparentMesh: 0
+--- !u!114 &5663239582614092590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322947784471087719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ac572609af7c10646a6327a0bcbf71f8, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &2190134760596699691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322947784471087719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5663239582614092590}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8905959309039144175}
+        m_MethodName: SetAccent
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1120683048572588063
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7322947784471087719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 635727e25c735994fb6f858716ba8247, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  message: 'Shortcut Key: |NoteSetAccent|'
+  offset: {x: 30, y: -7}
 --- !u!1 &8268137652120974474
 GameObject:
   m_ObjectHideFlags: 0
@@ -596,7 +1041,7 @@ RectTransform:
   m_Children:
   - {fileID: 23407923842927886}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 12
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1159,7 +1604,7 @@ RectTransform:
   m_Children:
   - {fileID: 8905959308467597390}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1380,7 +1825,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 8905959308192499609}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.3029028
+  m_Size: 0.32180777
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -1651,7 +2096,7 @@ RectTransform:
   - {fileID: 8905959308361770349}
   - {fileID: 8905959309748119697}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 18
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2050,7 +2495,7 @@ RectTransform:
   m_LocalScale: {x: 0.9999982, y: 0.9999982, z: 0.99999994}
   m_Children: []
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -3252,7 +3697,7 @@ RectTransform:
   - {fileID: 8905959308149960933}
   - {fileID: 8905959309319580415}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 14
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -4673,7 +5118,7 @@ RectTransform:
   - {fileID: 8905959308518896255}
   - {fileID: 8905959308579251413}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 16
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -5086,6 +5531,8 @@ MonoBehaviour:
   setNoteHopo: {fileID: 8905959309427221044}
   setNoteTap: {fileID: 8905959309541732413}
   setNoteCymbal: {fileID: 8905959308797420673}
+  setNoteAccent: {fileID: 0}
+  setNoteGhost: {fileID: 0}
   setDoubleKick: {fileID: 510745201807845836}
   altDoubleKick: {fileID: 2699465269500410265}
 --- !u!1 &8905959309049172589
@@ -5300,7 +5747,7 @@ RectTransform:
   - {fileID: 8905959308655948932}
   - {fileID: 8905959309035348280}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 17
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -5433,7 +5880,7 @@ RectTransform:
   m_LocalScale: {x: 0.9999982, y: 0.9999982, z: 0.99999994}
   m_Children: []
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 13
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -6281,6 +6728,8 @@ RectTransform:
   - {fileID: 8905959308797420687}
   - {fileID: 8905959309427221045}
   - {fileID: 8905959309541732410}
+  - {fileID: 2155723559591302775}
+  - {fileID: 8434495684698479768}
   - {fileID: 5134525491246602626}
   - {fileID: 2465886431515216233}
   - {fileID: 8905959308046723903}
@@ -7462,7 +7911,7 @@ RectTransform:
   m_Children:
   - {fileID: 8905959309551679632}
   m_Father: {fileID: 8905959309469288398}
-  m_RootOrder: 10
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/Moonscraper Chart Editor/Assets/Prefabs/UI/Inspectors/Note Inspector.prefab
+++ b/Moonscraper Chart Editor/Assets/Prefabs/UI/Inspectors/Note Inspector.prefab
@@ -1,5 +1,98 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &472094377925276241
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1380926345847036419}
+  - component: {fileID: 2191120996514407945}
+  - component: {fileID: 3604245972962766364}
+  - component: {fileID: 1747939083088663610}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1380926345847036419
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472094377925276241}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4994621059605444626}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -12.23, y: 2.3999996}
+  m_SizeDelta: {x: -60.256172, y: -3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2191120996514407945
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472094377925276241}
+  m_CullTransparentMesh: 0
+--- !u!114 &3604245972962766364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472094377925276241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 2e4970c185db220408da833322ff835e, type: 3}
+    m_FontSize: 13
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 1
+    m_MaxSize: 13
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Ghost
+--- !u!114 &1747939083088663610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 472094377925276241}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 0.5, y: -0.5}
+  m_UseGraphicAlpha: 1
 --- !u!1 &1269271537288858343
 GameObject:
   m_ObjectHideFlags: 0
@@ -93,6 +186,114 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
   m_EffectDistance: {x: 0.5, y: -0.5}
   m_UseGraphicAlpha: 1
+--- !u!1 &1492972814024740995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4994621059605444626}
+  - component: {fileID: 5317950251101876385}
+  - component: {fileID: 2638479172574005629}
+  m_Layer: 5
+  m_Name: Ghost Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4994621059605444626
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492972814024740995}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1107374816753176240}
+  - {fileID: 1380926345847036419}
+  m_Father: {fileID: 1789092518923863802}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 90.5, y: -178}
+  m_SizeDelta: {x: 124.9, y: 24.800003}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5317950251101876385
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492972814024740995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6979648034933296781}
+  toggleTransition: 1
+  graphic: {fileID: 5284771824598767998}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1789092518923863805}
+        m_MethodName: setDoubleKick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
+--- !u!114 &2638479172574005629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492972814024740995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 635727e25c735994fb6f858716ba8247, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  message: 'Shortcut Key: |ToggleNoteDoubleKick|'
+  offset: {x: 54, y: -2}
 --- !u!1 &1789092517947636573
 GameObject:
   m_ObjectHideFlags: 0
@@ -120,7 +321,7 @@ RectTransform:
   m_GameObject: {fileID: 1789092517947636573}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.000045, y: 1.000045, z: 0.9999633}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1789092518789567695}
   - {fileID: 1789092520025280414}
@@ -129,7 +330,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90.49998, y: -109.6}
+  m_AnchoredPosition: {x: 90.49998, y: -109}
   m_SizeDelta: {x: 124.9, y: 24.800003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1789092517947636560
@@ -495,7 +696,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90.5, y: -109.7}
+  m_AnchoredPosition: {x: 90.5, y: -109}
   m_SizeDelta: {x: 124.9, y: 24.800003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1789092518397369323
@@ -666,7 +867,7 @@ RectTransform:
   m_GameObject: {fileID: 1789092518702047641}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000064, y: 1.0000064, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1789092519270929617}
   - {fileID: 1789092519766262998}
@@ -675,7 +876,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90.5, y: -135.8}
+  m_AnchoredPosition: {x: 90.5, y: -132}
   m_SizeDelta: {x: 124.9, y: 24.800003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1789092518702047643
@@ -951,6 +1152,8 @@ RectTransform:
   - {fileID: 1789092518702047642}
   - {fileID: 1789092517947636574}
   - {fileID: 846496881365083491}
+  - {fileID: 6370213821824746265}
+  - {fileID: 4994621059605444626}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1013,6 +1216,8 @@ MonoBehaviour:
   forcedToggle: {fileID: 1789092518702047643}
   cymbalToggle: {fileID: 1789092517947636560}
   doubleKickToggle: {fileID: 5896545203298916698}
+  accentToggle: {fileID: 0}
+  ghostToggle: {fileID: 0}
   noteToolObject: {fileID: 0}
 --- !u!1 &1789092518936373222
 GameObject:
@@ -1604,6 +1809,79 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
   m_EffectDistance: {x: 0.5, y: -0.5}
   m_UseGraphicAlpha: 1
+--- !u!1 &2655724927648255618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1107374816753176240}
+  - component: {fileID: 2688832933640312504}
+  - component: {fileID: 6979648034933296781}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1107374816753176240
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2655724927648255618}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5496685990500277867}
+  m_Father: {fileID: 4994621059605444626}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 106, y: -6.2}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2688832933640312504
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2655724927648255618}
+  m_CullTransparentMesh: 0
+--- !u!114 &6979648034933296781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2655724927648255618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 215df866ab366044da883a5086b683fb, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &2799351728016592043
 GameObject:
   m_ObjectHideFlags: 0
@@ -1631,7 +1909,7 @@ RectTransform:
   m_GameObject: {fileID: 2799351728016592043}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000064, y: 1.0000064, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5293503735583581851}
   - {fileID: 3012408906049687427}
@@ -1640,7 +1918,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90.5, y: -135.8}
+  m_AnchoredPosition: {x: 90.5, y: -132}
   m_SizeDelta: {x: 124.9, y: 24.800003}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5896545203298916698
@@ -1712,6 +1990,78 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   message: 'Shortcut Key: |ToggleNoteDoubleKick|'
   offset: {x: 54, y: -2}
+--- !u!1 &3093913728168863572
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1802347307448029025}
+  - component: {fileID: 8842833699233274209}
+  - component: {fileID: 7705215615891083196}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1802347307448029025
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3093913728168863572}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 9117411461414989797}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8842833699233274209
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3093913728168863572}
+  m_CullTransparentMesh: 0
+--- !u!114 &7705215615891083196
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3093913728168863572}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
 --- !u!1 &5982931617846482728
 GameObject:
   m_ObjectHideFlags: 0
@@ -1785,6 +2135,244 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+--- !u!1 &6032991140013573347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5496685990500277867}
+  - component: {fileID: 4172696692847824842}
+  - component: {fileID: 5284771824598767998}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5496685990500277867
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6032991140013573347}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1107374816753176240}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4172696692847824842
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6032991140013573347}
+  m_CullTransparentMesh: 0
+--- !u!114 &5284771824598767998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6032991140013573347}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!1 &7579948165063706171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9117411461414989797}
+  - component: {fileID: 7417984061855327496}
+  - component: {fileID: 9100450187788061457}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9117411461414989797
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579948165063706171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1802347307448029025}
+  m_Father: {fileID: 6370213821824746265}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 106, y: -6.2}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7417984061855327496
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579948165063706171}
+  m_CullTransparentMesh: 0
+--- !u!114 &9100450187788061457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579948165063706171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 215df866ab366044da883a5086b683fb, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!1 &7785290133199427793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2820752637428575779}
+  - component: {fileID: 1323364283999184964}
+  - component: {fileID: 360748827782535568}
+  - component: {fileID: 4321241249952078582}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2820752637428575779
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7785290133199427793}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6370213821824746265}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -18.3, y: 2.3999996}
+  m_SizeDelta: {x: -48.1, y: -3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1323364283999184964
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7785290133199427793}
+  m_CullTransparentMesh: 0
+--- !u!114 &360748827782535568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7785290133199427793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 2e4970c185db220408da833322ff835e, type: 3}
+    m_FontSize: 13
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Accent
+--- !u!114 &4321241249952078582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7785290133199427793}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
+  m_EffectDistance: {x: 0.5, y: -0.5}
+  m_UseGraphicAlpha: 1
 --- !u!1 &7945724395894438852
 GameObject:
   m_ObjectHideFlags: 0
@@ -1857,3 +2445,111 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+--- !u!1 &9003832070663116481
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6370213821824746265}
+  - component: {fileID: 378857780727473235}
+  - component: {fileID: 1475223222326869801}
+  m_Layer: 5
+  m_Name: Accent Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6370213821824746265
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9003832070663116481}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 9117411461414989797}
+  - {fileID: 2820752637428575779}
+  m_Father: {fileID: 1789092518923863802}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 90.49998, y: -155}
+  m_SizeDelta: {x: 124.9, y: 24.800003}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &378857780727473235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9003832070663116481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9100450187788061457}
+  toggleTransition: 1
+  graphic: {fileID: 7705215615891083196}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1789092518923863805}
+        m_MethodName: setCymbal
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
+--- !u!114 &1475223222326869801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9003832070663116481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 635727e25c735994fb6f858716ba8247, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  message: 'Shortcut Key: |ToggleNoteCymbal|'
+  offset: {x: 54, y: -2}

--- a/Moonscraper Chart Editor/Assets/Scenes/Game/Main Editor.unity
+++ b/Moonscraper Chart Editor/Assets/Scenes/Game/Main Editor.unity
@@ -41685,7 +41685,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -1.1350098, y: -202.10538}
+  m_AnchoredPosition: {x: -1.1350098, y: -202.1054}
   m_SizeDelta: {x: -16.200012, y: 273.1942}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1783824858
@@ -49915,7 +49915,7 @@ PrefabInstance:
     - target: {fileID: 4676915068451462971, guid: 8585870860c40fe4c85efa017d4bc340,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199585
+      value: -21.199463
       objectReference: {fileID: 0}
     - target: {fileID: 4676915068451462971, guid: 8585870860c40fe4c85efa017d4bc340,
         type: 3}
@@ -50617,7 +50617,7 @@ PrefabInstance:
     - target: {fileID: 685299099908483682, guid: 16d324b49da67a547909caccda211f4c,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199585
+      value: -21.199463
       objectReference: {fileID: 0}
     - target: {fileID: 685299099908483682, guid: 16d324b49da67a547909caccda211f4c,
         type: 3}
@@ -51026,7 +51026,7 @@ PrefabInstance:
     - target: {fileID: 1301899982732144092, guid: 50e7de0d989f0a74cad9c1926db9987f,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -101.99884
+      value: -101.99883
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50e7de0d989f0a74cad9c1926db9987f, type: 3}
@@ -51115,7 +51115,7 @@ PrefabInstance:
     - target: {fileID: 1789092518923863802, guid: 006d812f8b07c2445b37919fcdc16c16,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199585
+      value: -21.199463
       objectReference: {fileID: 0}
     - target: {fileID: 1789092518923863802, guid: 006d812f8b07c2445b37919fcdc16c16,
         type: 3}
@@ -51402,7 +51402,7 @@ PrefabInstance:
     - target: {fileID: 4289244241869284558, guid: a42c0e6dbb8072644a562b198b8ffdc2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199585
+      value: -21.199463
       objectReference: {fileID: 0}
     - target: {fileID: 4289244241869284558, guid: a42c0e6dbb8072644a562b198b8ffdc2,
         type: 3}
@@ -51526,7 +51526,7 @@ PrefabInstance:
     - target: {fileID: 4589337267236304948, guid: 8c670304ac77eb44dbe82e260f7e830a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199585
+      value: -21.199463
       objectReference: {fileID: 0}
     - target: {fileID: 4589337267236304948, guid: 8c670304ac77eb44dbe82e260f7e830a,
         type: 3}
@@ -51736,10 +51736,210 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 652242549}
     m_Modifications:
+    - target: {fileID: 2155723559591302775, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2155723559591302775, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2155723559591302775, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 2155723559591302775, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -136.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465886431515216233, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465886431515216233, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465886431515216233, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 2465886431515216233, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -198.90001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2787414645888487463, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2787414645888487463, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2787414645888487463, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 2787414645888487463, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -284.55002
+      objectReference: {fileID: 0}
+    - target: {fileID: 3632723642605481842, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3632723642605481842, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3632723642605481842, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 3632723642605481842, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -306.00003
+      objectReference: {fileID: 0}
     - target: {fileID: 4080964883834491875, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0.049999237
+      objectReference: {fileID: 0}
+    - target: {fileID: 5134525491246602626, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5134525491246602626, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5134525491246602626, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 5134525491246602626, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -178.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5715264147786255540, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5715264147786255540, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5715264147786255540, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 5715264147786255540, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -370.80002
+      objectReference: {fileID: 0}
+    - target: {fileID: 8434495684698479768, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8434495684698479768, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8434495684698479768, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8434495684698479768, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -157.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307842756695, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307842756695, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307842756695, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307842756695, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10.549999
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307876777098, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307876777098, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307876777098, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307876777098, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -31.999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307890605117, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307890605117, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307890605117, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959307890605117, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -241.30002
       objectReference: {fileID: 0}
     - target: {fileID: 8905959307905298820, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
@@ -51751,10 +51951,50 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: -17
       objectReference: {fileID: 0}
+    - target: {fileID: 8905959308000523257, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308000523257, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308000523257, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308000523257, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -436.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308046723903, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308046723903, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308046723903, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308046723903, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -219.85002
+      objectReference: {fileID: 0}
     - target: {fileID: 8905959308192499609, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.3297932
+      value: 0.6856286
       objectReference: {fileID: 0}
     - target: {fileID: 8905959308192499609, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
@@ -51775,6 +52015,86 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.x
       value: -9.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308209507522, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308209507522, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308209507522, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308209507522, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -53.299995
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308499275441, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308499275441, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308499275441, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308499275441, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -348.95004
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308797420687, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308797420687, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308797420687, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308797420687, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -74.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308907421141, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308907421141, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308907421141, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959308907421141, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -392.65002
       objectReference: {fileID: 0}
     - target: {fileID: 8905959309039144170, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
@@ -51834,7 +52154,7 @@ PrefabInstance:
     - target: {fileID: 8905959309039144170, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199585
+      value: -21.199463
       objectReference: {fileID: 0}
     - target: {fileID: 8905959309039144170, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
@@ -51891,6 +52211,56 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8905959309039144175, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: setNoteAccent
+      value: 
+      objectReference: {fileID: 8905959308695698443}
+    - target: {fileID: 8905959309039144175, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: setNoteGhost
+      value: 
+      objectReference: {fileID: 8905959308695698442}
+    - target: {fileID: 8905959309086148036, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309086148036, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309086148036, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309086148036, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -414.55002
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309167392015, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309167392015, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309167392015, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309167392015, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -327.45
+      objectReference: {fileID: 0}
     - target: {fileID: 8905959309236758917, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -51904,12 +52274,77 @@ PrefabInstance:
     - target: {fileID: 8905959309236758917, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.00000011920929
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309427221045, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309427221045, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309427221045, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309427221045, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -94.9
       objectReference: {fileID: 0}
     - target: {fileID: 8905959309469288398, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309469288398, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 447.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309541732410, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309541732410, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309541732410, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309541732410, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -115.700005
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309842602995, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309842602995, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309842602995, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 51.693493
+      objectReference: {fileID: 0}
+    - target: {fileID: 8905959309842602995, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -263.10004
       objectReference: {fileID: 0}
     - target: {fileID: 8905959309906869175, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
@@ -51933,6 +52368,30 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6d3538754e6763149bf3ab76a2bab8e5, type: 3}
+--- !u!114 &8905959308695698442 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8410474288149985642, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+    type: 3}
+  m_PrefabInstance: {fileID: 8905959308695698441}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8905959308695698443 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2190134760596699691, guid: 6d3538754e6763149bf3ab76a2bab8e5,
+    type: 3}
+  m_PrefabInstance: {fileID: 8905959308695698441}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &9034363378365396455
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Moonscraper Chart Editor/Assets/Scenes/Game/Main Editor.unity
+++ b/Moonscraper Chart Editor/Assets/Scenes/Game/Main Editor.unity
@@ -4421,7 +4421,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000005722046, y: 0}
+  m_AnchoredPosition: {x: 0.000032424927, y: 0}
   m_SizeDelta: {x: 0, y: 97.2}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &178945491
@@ -5259,7 +5259,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -85}
+  m_AnchoredPosition: {x: 10.349976, y: -85}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &215822995
@@ -6233,7 +6233,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -10}
+  m_AnchoredPosition: {x: 10.349976, y: -10}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &274773924
@@ -8918,7 +8918,7 @@ Transform:
   m_GameObject: {fileID: 428521652}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
-  m_LocalScale: {x: 16.014084, y: 9, z: 1}
+  m_LocalScale: {x: 16.50579, y: 9, z: 1}
   m_Children: []
   m_Father: {fileID: 171801953}
   m_RootOrder: 0
@@ -11681,7 +11681,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 980262014}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.8948514
+  m_Size: 0.85400367
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -17734,7 +17734,7 @@ PrefabInstance:
     - target: {fileID: 224149958098439174, guid: 1ad36d040cad9c24b8428400dba9c534,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.2999878
+      value: 0.30004883
       objectReference: {fileID: 0}
     - target: {fileID: 224283182612702362, guid: 1ad36d040cad9c24b8428400dba9c534,
         type: 3}
@@ -20981,7 +20981,7 @@ PrefabInstance:
     - target: {fileID: 4456365409512320624, guid: 9cd8f3ce6ccdb0c47adb7289f20df64d,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -5.1000977
+      value: -5.1000824
       objectReference: {fileID: 0}
     - target: {fileID: 4456424739296497366, guid: 9cd8f3ce6ccdb0c47adb7289f20df64d,
         type: 3}
@@ -22781,7 +22781,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -125}
+  m_AnchoredPosition: {x: 10.349976, y: -125}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &992596841
@@ -24262,7 +24262,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -35}
+  m_AnchoredPosition: {x: 10.349976, y: -35}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1049502288
@@ -25972,7 +25972,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.71425885, y: 1}
   m_AnchorMax: {x: 0.71425885, y: 1}
-  m_AnchoredPosition: {x: 7, y: 2.5998535}
+  m_AnchoredPosition: {x: 7, y: 2.5998383}
   m_SizeDelta: {x: 378, y: 24.799988}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1140052148
@@ -26920,8 +26920,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 651365792}
   m_HandleRect: {fileID: 651365791}
   m_Direction: 2
-  m_Value: 0.999997
-  m_Size: 0.88376063
+  m_Value: 0.99999845
+  m_Size: 0.8482709
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -27943,7 +27943,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 436, y: -14.999908}
+  m_AnchoredPosition: {x: 436, y: -14.999863}
   m_SizeDelta: {x: -885, y: -44}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1237180285
@@ -28736,7 +28736,7 @@ Transform:
   m_GameObject: {fileID: 1265937412}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 16.014084, y: 9, z: 1}
+  m_LocalScale: {x: 16.50579, y: 9, z: 1}
   m_Children: []
   m_Father: {fileID: 1002528588}
   m_RootOrder: 0
@@ -30514,7 +30514,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.13999939}
+  m_AnchoredPosition: {x: 0, y: 0.14000702}
   m_SizeDelta: {x: 0.21490002, y: 36.48}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &1317847545
@@ -30629,7 +30629,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -60}
+  m_AnchoredPosition: {x: 10.349976, y: -60}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1318309600
@@ -34014,7 +34014,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -100}
+  m_AnchoredPosition: {x: 10.349976, y: -100}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1431854988
@@ -34757,7 +34757,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -1.4999237, y: -16.175049}
+  m_AnchoredPosition: {x: -1.4998779, y: -16.175049}
   m_SizeDelta: {x: -23, y: -53.65}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1485123740
@@ -36855,7 +36855,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 905771893, guid: 67c33ce5e4f82a84c8c5bf1af1f9bd57, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -79.18002
+      value: -79.180016
       objectReference: {fileID: 0}
     - target: {fileID: 905771893, guid: 67c33ce5e4f82a84c8c5bf1af1f9bd57, type: 3}
       propertyPath: m_SizeDelta.x
@@ -37416,8 +37416,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1277142301}
   m_HandleRect: {fileID: 1277142300}
   m_Direction: 0
-  m_Value: 0
-  m_Size: 0.99999976
+  m_Value: 1
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -41685,7 +41685,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -1.1350098, y: -202.10533}
+  m_AnchoredPosition: {x: -1.1350098, y: -202.10538}
   m_SizeDelta: {x: -16.200012, y: 273.1942}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1783824858
@@ -49915,7 +49915,7 @@ PrefabInstance:
     - target: {fileID: 4676915068451462971, guid: 8585870860c40fe4c85efa017d4bc340,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199524
+      value: -21.199585
       objectReference: {fileID: 0}
     - target: {fileID: 4676915068451462971, guid: 8585870860c40fe4c85efa017d4bc340,
         type: 3}
@@ -50017,7 +50017,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10.350006, y: -10}
+  m_AnchoredPosition: {x: 10.349976, y: -10}
   m_SizeDelta: {x: 20.700012, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2134430380
@@ -50617,7 +50617,7 @@ PrefabInstance:
     - target: {fileID: 685299099908483682, guid: 16d324b49da67a547909caccda211f4c,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199524
+      value: -21.199585
       objectReference: {fileID: 0}
     - target: {fileID: 685299099908483682, guid: 16d324b49da67a547909caccda211f4c,
         type: 3}
@@ -51026,7 +51026,7 @@ PrefabInstance:
     - target: {fileID: 1301899982732144092, guid: 50e7de0d989f0a74cad9c1926db9987f,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -101.99886
+      value: -101.99884
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50e7de0d989f0a74cad9c1926db9987f, type: 3}
@@ -51037,6 +51037,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 652242549}
     m_Modifications:
+    - target: {fileID: 378857780727473235, guid: 006d812f8b07c2445b37919fcdc16c16,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: setAccent
+      objectReference: {fileID: 0}
+    - target: {fileID: 1475223222326869801, guid: 006d812f8b07c2445b37919fcdc16c16,
+        type: 3}
+      propertyPath: message
+      value: 'Shortcut Key: |ToggleNoteAccent|'
+      objectReference: {fileID: 0}
     - target: {fileID: 1789092518923863801, guid: 006d812f8b07c2445b37919fcdc16c16,
         type: 3}
       propertyPath: m_Name
@@ -51105,7 +51115,7 @@ PrefabInstance:
     - target: {fileID: 1789092518923863802, guid: 006d812f8b07c2445b37919fcdc16c16,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199524
+      value: -21.199585
       objectReference: {fileID: 0}
     - target: {fileID: 1789092518923863802, guid: 006d812f8b07c2445b37919fcdc16c16,
         type: 3}
@@ -51157,8 +51167,52 @@ PrefabInstance:
       propertyPath: noteToolObject
       value: 
       objectReference: {fileID: 1796968329}
+    - target: {fileID: 1789092518923863805, guid: 006d812f8b07c2445b37919fcdc16c16,
+        type: 3}
+      propertyPath: accentToggle
+      value: 
+      objectReference: {fileID: 1789092518640820506}
+    - target: {fileID: 1789092518923863805, guid: 006d812f8b07c2445b37919fcdc16c16,
+        type: 3}
+      propertyPath: ghostToggle
+      value: 
+      objectReference: {fileID: 1789092518640820505}
+    - target: {fileID: 2638479172574005629, guid: 006d812f8b07c2445b37919fcdc16c16,
+        type: 3}
+      propertyPath: message
+      value: 'Shortcut Key: |ToggleNoteGhost|'
+      objectReference: {fileID: 0}
+    - target: {fileID: 5317950251101876385, guid: 006d812f8b07c2445b37919fcdc16c16,
+        type: 3}
+      propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: setGhost
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 006d812f8b07c2445b37919fcdc16c16, type: 3}
+--- !u!114 &1789092518640820505 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5317950251101876385, guid: 006d812f8b07c2445b37919fcdc16c16,
+    type: 3}
+  m_PrefabInstance: {fileID: 1789092518640820504}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1789092518640820506 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 378857780727473235, guid: 006d812f8b07c2445b37919fcdc16c16,
+    type: 3}
+  m_PrefabInstance: {fileID: 1789092518640820504}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 2109663825, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3477481083982229059
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -51348,7 +51402,7 @@ PrefabInstance:
     - target: {fileID: 4289244241869284558, guid: a42c0e6dbb8072644a562b198b8ffdc2,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199524
+      value: -21.199585
       objectReference: {fileID: 0}
     - target: {fileID: 4289244241869284558, guid: a42c0e6dbb8072644a562b198b8ffdc2,
         type: 3}
@@ -51472,7 +51526,7 @@ PrefabInstance:
     - target: {fileID: 4589337267236304948, guid: 8c670304ac77eb44dbe82e260f7e830a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199524
+      value: -21.199585
       objectReference: {fileID: 0}
     - target: {fileID: 4589337267236304948, guid: 8c670304ac77eb44dbe82e260f7e830a,
         type: 3}
@@ -51780,7 +51834,7 @@ PrefabInstance:
     - target: {fileID: 8905959309039144170, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -21.199524
+      value: -21.199585
       objectReference: {fileID: 0}
     - target: {fileID: 8905959309039144170, guid: 6d3538754e6763149bf3ab76a2bab8e5,
         type: 3}

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/ChartEditor/EditorInteractions/HighwayObjectTools/Placeable/PlaceNoteController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/ChartEditor/EditorInteractions/HighwayObjectTools/Placeable/PlaceNoteController.cs
@@ -663,8 +663,8 @@ public class PlaceNoteController : ObjectlessTool {
         {
             cymbalInteractable = NoteFunctions.AllowedToBeCymbal(note);
             doubleKickInteractable = NoteFunctions.AllowedToBeDoubleKick(note, editor.currentDifficulty);
-            accentInteractable = NoteFunctions.AllowedToBeAccentOrGhost(note);
-            ghostInteractable = NoteFunctions.AllowedToBeAccentOrGhost(note);
+            accentInteractable = NoteFunctions.AllowedToBeAccent(note);
+            ghostInteractable = NoteFunctions.AllowedToBeGhost(note);
         }
     }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/ChartEditor/EditorInteractions/HighwayObjectTools/Placeable/PlaceNoteController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/ChartEditor/EditorInteractions/HighwayObjectTools/Placeable/PlaceNoteController.cs
@@ -25,6 +25,8 @@ public class PlaceNoteController : ObjectlessTool {
     public bool tapInteractable { get; private set; }
     public bool cymbalInteractable { get; private set; }
     public bool doubleKickInteractable { get; private set; }
+    public bool accentInteractable { get; private set; }
+    public bool ghostInteractable { get; private set; }
 
     // Keyboard mode sustain dragging
     Note[] heldNotes;
@@ -72,6 +74,8 @@ public class PlaceNoteController : ObjectlessTool {
         tapInteractable = true;
         cymbalInteractable = true;
         doubleKickInteractable = true;
+        accentInteractable = true;
+        ghostInteractable = true;
 
         CurrentNotePlacementUpdate = UpdateMouseBurstMode;
 
@@ -191,6 +195,8 @@ public class PlaceNoteController : ObjectlessTool {
         forcedInteractable = true;
         tapInteractable = true;
         cymbalInteractable = true;
+        accentInteractable = true;
+        ghostInteractable = true;
 
         LaneInfo laneInfo = editor.laneInfo;
         UpdateSnappedPos();
@@ -228,6 +234,8 @@ public class PlaceNoteController : ObjectlessTool {
         forcedInteractable = true;
         tapInteractable = true;
         cymbalInteractable = true;
+        accentInteractable = true;
+        ghostInteractable = true;
 
         LaneInfo laneInfo = editor.laneInfo;
         UpdateSnappedPos();
@@ -655,6 +663,8 @@ public class PlaceNoteController : ObjectlessTool {
         {
             cymbalInteractable = NoteFunctions.AllowedToBeCymbal(note);
             doubleKickInteractable = NoteFunctions.AllowedToBeDoubleKick(note, editor.currentDifficulty);
+            accentInteractable = NoteFunctions.AllowedToBeAccentOrGhost(note);
+            ghostInteractable = NoteFunctions.AllowedToBeAccentOrGhost(note);
         }
     }
 
@@ -685,6 +695,16 @@ public class PlaceNoteController : ObjectlessTool {
         if (!doubleKickInteractable && gameObject.activeSelf)
         {
             flags &= ~Note.Flags.DoubleKick;
+        }
+
+        if (!accentInteractable && gameObject.activeSelf)
+        {
+            flags &= ~Note.Flags.ProDrums_Accent;
+        }
+
+        if (!ghostInteractable && gameObject.activeSelf)
+        {
+            flags &= ~Note.Flags.ProDrums_Ghost;
         }
 
         flags &= ~bannedFlags;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/ChartEditorExtentions/NoteFunctions.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/ChartEditorExtentions/NoteFunctions.cs
@@ -234,7 +234,12 @@ public static class NoteFunctions {
         return note.IsOpenNote();
     }
 
-    public static bool AllowedToBeAccentOrGhost(Note note)
+    public static bool AllowedToBeAccent(Note note)
+    {
+        return !note.IsOpenNote();
+    }
+
+    public static bool AllowedToBeGhost(Note note)
     {
         return !note.IsOpenNote();
     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/ChartEditorExtentions/NoteFunctions.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/ChartEditorExtentions/NoteFunctions.cs
@@ -234,6 +234,11 @@ public static class NoteFunctions {
         return note.IsOpenNote();
     }
 
+    public static bool AllowedToBeAccentOrGhost(Note note)
+    {
+        return !note.IsOpenNote();
+    }
+
     public static Note.Flags GetFlagsToSetType(this Note note, Note.NoteType type)
     {
         Note.Flags flags = Note.Flags.None;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Events/Note.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Events/Note.cs
@@ -498,7 +498,7 @@ namespace MoonscraperChartEditor.Song
                 case Chart.GameMode.Guitar:
                 case Chart.GameMode.GHLGuitar:
                     {
-                        bannedFlags = Flags.ProDrums_Cymbal;
+                        bannedFlags = Flags.ProDrums_Cymbal | Flags.ProDrums_Accent | Flags.ProDrums_Ghost;
                         break;
                     }
                 case Chart.GameMode.Drums:

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -59,14 +59,14 @@ namespace MoonscraperChartEditor.Song.IO
     };
 
         // Flags to skip adding if the corresponding flag is already present
-        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagIgnoreLookup = new Dictionary<Note.Flags, Note.Flags>()
+        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteBlockingFlagsLookup = new Dictionary<Note.Flags, Note.Flags>()
     {
         { Note.Flags.Forced, Note.Flags.Tap },
         { Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent },
     };
 
         // Flags to remove if the corresponding flag is being added
-        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagOverrideLookup = c_noteFlagIgnoreLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagsToRemoveLookup = c_noteBlockingFlagsLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
         public static readonly Dictionary<int, int> c_drumNoteToSaveNumberLookup = c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -58,6 +58,16 @@ namespace MoonscraperChartEditor.Song.IO
         { 5, (int)Note.DrumPad.Green     },
     };
 
+        // Flags to skip adding if the corresponding flag is already present
+        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagIgnoreLookup = new Dictionary<Note.Flags, Note.Flags>()
+    {
+        { Note.Flags.Forced, Note.Flags.Tap },
+        { Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent },
+    };
+
+        // Flags to remove if the corresponding flag is being added
+        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagOverrideLookup = c_noteFlagIgnoreLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+
         public static readonly Dictionary<int, int> c_drumNoteToSaveNumberLookup = c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
         public static readonly Dictionary<int, Note.Flags> c_drumFlagNumLookup = new Dictionary<int, Note.Flags>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -26,6 +26,9 @@ namespace MoonscraperChartEditor.Song.IO
 
         public const int c_proDrumsOffset = 64;
         public const int c_instrumentPlusOffset = 32;
+        public const int c_drumsAccentOffset = 33;
+        public const int c_drumsGhostOffset = 39;
+
         public const int c_starpowerId = 2;
         public const int c_starpowerDrumFillId = 64;
 
@@ -63,6 +66,18 @@ namespace MoonscraperChartEditor.Song.IO
         { c_proDrumsOffset + 3, Note.Flags.ProDrums_Cymbal },       // Blue save num from c_drumNoteNumLookup
         { c_proDrumsOffset + 4, Note.Flags.ProDrums_Cymbal },       // Orange (Green in 4-lane) save num from c_drumNoteNumLookup
         { c_instrumentPlusOffset, Note.Flags.InstrumentPlus },      // Double Kick
+
+        { c_drumsAccentOffset + 1, Note.Flags.ProDrums_Accent },    // Red accent
+        { c_drumsAccentOffset + 2, Note.Flags.ProDrums_Accent },    // Yellow accent
+        { c_drumsAccentOffset + 3, Note.Flags.ProDrums_Accent },    // Blue accent
+        { c_drumsAccentOffset + 4, Note.Flags.ProDrums_Accent },    // Orange accent
+        { c_drumsAccentOffset + 5, Note.Flags.ProDrums_Accent },    // Green accent
+
+        { c_drumsGhostOffset + 1, Note.Flags.ProDrums_Ghost },      // Red ghost
+        { c_drumsGhostOffset + 2, Note.Flags.ProDrums_Ghost },      // Yellow ghost
+        { c_drumsGhostOffset + 3, Note.Flags.ProDrums_Ghost },      // Blue ghost
+        { c_drumsGhostOffset + 4, Note.Flags.ProDrums_Ghost },      // Orange ghost
+        { c_drumsGhostOffset + 5, Note.Flags.ProDrums_Ghost },      // Green ghost
     };
 
         // Default flags, mark as cymbal for pro drums automatically. Also used for choosing whether to write flag information or not if it's like this by default in the first place.
@@ -74,6 +89,24 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.DrumPad.Blue      , Note.Flags.None },
         { (int)Note.DrumPad.Orange    , Note.Flags.None },   // Orange becomes green during 4-lane
         { (int)Note.DrumPad.Green     , Note.Flags.None },
+    };
+
+        public static readonly Dictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
+    {
+        { (int)Note.DrumPad.Red       , c_drumsAccentOffset + 1 },
+        { (int)Note.DrumPad.Yellow    , c_drumsAccentOffset + 2 },
+        { (int)Note.DrumPad.Blue      , c_drumsAccentOffset + 3 },
+        { (int)Note.DrumPad.Orange    , c_drumsAccentOffset + 4 },
+        { (int)Note.DrumPad.Green     , c_drumsAccentOffset + 5 },
+    };
+
+        public static readonly Dictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
+    {
+        { (int)Note.DrumPad.Red       , c_drumsGhostOffset + 1 },
+        { (int)Note.DrumPad.Yellow    , c_drumsGhostOffset + 2 },
+        { (int)Note.DrumPad.Blue      , c_drumsGhostOffset + 3 },
+        { (int)Note.DrumPad.Orange    , c_drumsGhostOffset + 4 },
+        { (int)Note.DrumPad.Green     , c_drumsGhostOffset + 5 },
     };
 
         public static readonly Dictionary<int, int> c_ghlNoteNumLookup = new Dictionary<int, int>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -90,7 +90,7 @@ namespace MoonscraperChartEditor.Song.IO
         { c_drumsGhostOffset + 5, Note.Flags.ProDrums_Ghost },      // Green ghost
     };
 
-        // Default flags, mark as cymbal for pro drums automatically. Also used for choosing whether to write flag information or not if it's like this by default in the first place.
+        // Default flags for drums notes
         public static readonly Dictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
     {
         { (int)Note.DrumPad.Kick      , Note.Flags.None },

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -32,7 +32,7 @@ namespace MoonscraperChartEditor.Song.IO
         public const int c_starpowerId = 2;
         public const int c_starpowerDrumFillId = 64;
 
-        public static readonly Dictionary<int, int> c_guitarNoteNumLookup = new Dictionary<int, int>()
+        public static readonly IReadOnlyDictionary<int, int> c_guitarNoteNumLookup = new Dictionary<int, int>()
     {
         { 0, (int)Note.GuitarFret.Green     },
         { 1, (int)Note.GuitarFret.Red       },
@@ -42,13 +42,13 @@ namespace MoonscraperChartEditor.Song.IO
         { 7, (int)Note.GuitarFret.Open      },
     };
 
-        public static readonly Dictionary<int, Note.Flags> c_guitarFlagNumLookup = new Dictionary<int, Note.Flags>()
+        public static readonly IReadOnlyDictionary<int, Note.Flags> c_guitarFlagNumLookup = new Dictionary<int, Note.Flags>()
     {
         { 5      , Note.Flags.Forced },
         { 6      , Note.Flags.Tap },
     };
 
-        public static readonly Dictionary<int, int> c_drumNoteNumLookup = new Dictionary<int, int>()
+        public static readonly IReadOnlyDictionary<int, int> c_drumNoteNumLookup = new Dictionary<int, int>()
     {
         { 0, (int)Note.DrumPad.Kick      },
         { 1, (int)Note.DrumPad.Red       },
@@ -59,17 +59,17 @@ namespace MoonscraperChartEditor.Song.IO
     };
 
         // Flags to skip adding if the corresponding flag is already present
-        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteBlockingFlagsLookup = new Dictionary<Note.Flags, Note.Flags>()
+        public static readonly IReadOnlyDictionary<Note.Flags, Note.Flags> c_noteBlockingFlagsLookup = new Dictionary<Note.Flags, Note.Flags>()
     {
         { Note.Flags.Forced, Note.Flags.Tap },
         { Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent },
     };
 
         // Flags to remove if the corresponding flag is being added
-        public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagsToRemoveLookup = c_noteBlockingFlagsLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        public static readonly IReadOnlyDictionary<Note.Flags, Note.Flags> c_noteFlagsToRemoveLookup = c_noteBlockingFlagsLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
         // Default flags for drums notes
-        public static readonly Dictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
+        public static readonly IReadOnlyDictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
     {
         { (int)Note.DrumPad.Kick      , Note.Flags.None },
         { (int)Note.DrumPad.Red       , Note.Flags.None },
@@ -79,7 +79,7 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.DrumPad.Green     , Note.Flags.None },
     };
 
-        public static readonly Dictionary<int, int> c_ghlNoteNumLookup = new Dictionary<int, int>()
+        public static readonly IReadOnlyDictionary<int, int> c_ghlNoteNumLookup = new Dictionary<int, int>()
     {
         { 0, (int)Note.GHLiveGuitarFret.White1     },
         { 1, (int)Note.GHLiveGuitarFret.White2       },
@@ -90,9 +90,9 @@ namespace MoonscraperChartEditor.Song.IO
         { 7, (int)Note.GHLiveGuitarFret.Open      },
     };
 
-        public static readonly Dictionary<int, Note.Flags> c_ghlFlagNumLookup = c_guitarFlagNumLookup;
+        public static readonly IReadOnlyDictionary<int, Note.Flags> c_ghlFlagNumLookup = c_guitarFlagNumLookup;
 
-        public static readonly Dictionary<string, Song.Difficulty> c_trackNameToTrackDifficultyLookup = new Dictionary<string, Song.Difficulty>()
+        public static readonly IReadOnlyDictionary<string, Song.Difficulty> c_trackNameToTrackDifficultyLookup = new Dictionary<string, Song.Difficulty>()
     {
         { "Easy",   Song.Difficulty.Easy    },
         { "Medium", Song.Difficulty.Medium  },
@@ -100,7 +100,7 @@ namespace MoonscraperChartEditor.Song.IO
         { "Expert", Song.Difficulty.Expert  },
     };
 
-        public static readonly Dictionary<string, Song.Instrument> c_instrumentStrToEnumLookup = new Dictionary<string, Song.Instrument>()
+        public static readonly IReadOnlyDictionary<string, Song.Instrument> c_instrumentStrToEnumLookup = new Dictionary<string, Song.Instrument>()
     {
         { "Single",         Song.Instrument.Guitar },
         { "DoubleGuitar",   Song.Instrument.GuitarCoop },
@@ -112,7 +112,7 @@ namespace MoonscraperChartEditor.Song.IO
         { "GHLBass",        Song.Instrument.GHLiveBass },
     };
 
-        public static readonly Dictionary<Song.Instrument, Song.Instrument> c_instrumentParsingTypeLookup = new Dictionary<Song.Instrument, Song.Instrument>()
+        public static readonly IReadOnlyDictionary<Song.Instrument, Song.Instrument> c_instrumentParsingTypeLookup = new Dictionary<Song.Instrument, Song.Instrument>()
     {
         // Other instruments default to loading as a guitar type track
         { Song.Instrument.Drums,          Song.Instrument.Drums },

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -81,24 +81,6 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.DrumPad.Green     , Note.Flags.None },
     };
 
-        public static readonly Dictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
-    {
-        { (int)Note.DrumPad.Red       , c_drumsAccentOffset + 1 },
-        { (int)Note.DrumPad.Yellow    , c_drumsAccentOffset + 2 },
-        { (int)Note.DrumPad.Blue      , c_drumsAccentOffset + 3 },
-        { (int)Note.DrumPad.Orange    , c_drumsAccentOffset + 4 },
-        { (int)Note.DrumPad.Green     , c_drumsAccentOffset + 5 },
-    };
-
-        public static readonly Dictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
-    {
-        { (int)Note.DrumPad.Red       , c_drumsGhostOffset + 1 },
-        { (int)Note.DrumPad.Yellow    , c_drumsGhostOffset + 2 },
-        { (int)Note.DrumPad.Blue      , c_drumsGhostOffset + 3 },
-        { (int)Note.DrumPad.Orange    , c_drumsGhostOffset + 4 },
-        { (int)Note.DrumPad.Green     , c_drumsGhostOffset + 5 },
-    };
-
         public static readonly Dictionary<int, int> c_ghlNoteNumLookup = new Dictionary<int, int>()
     {
         { 0, (int)Note.GHLiveGuitarFret.White1     },

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -33,82 +33,82 @@ namespace MoonscraperChartEditor.Song.IO
         public const int c_starpowerDrumFillId = 64;
 
         public static readonly IReadOnlyDictionary<int, int> c_guitarNoteNumLookup = new Dictionary<int, int>()
-    {
-        { 0, (int)Note.GuitarFret.Green     },
-        { 1, (int)Note.GuitarFret.Red       },
-        { 2, (int)Note.GuitarFret.Yellow    },
-        { 3, (int)Note.GuitarFret.Blue      },
-        { 4, (int)Note.GuitarFret.Orange    },
-        { 7, (int)Note.GuitarFret.Open      },
-    };
+        {
+            { 0, (int)Note.GuitarFret.Green     },
+            { 1, (int)Note.GuitarFret.Red       },
+            { 2, (int)Note.GuitarFret.Yellow    },
+            { 3, (int)Note.GuitarFret.Blue      },
+            { 4, (int)Note.GuitarFret.Orange    },
+            { 7, (int)Note.GuitarFret.Open      },
+        };
 
         public static readonly IReadOnlyDictionary<int, Note.Flags> c_guitarFlagNumLookup = new Dictionary<int, Note.Flags>()
-    {
-        { 5      , Note.Flags.Forced },
-        { 6      , Note.Flags.Tap },
-    };
+        {
+            { 5      , Note.Flags.Forced },
+            { 6      , Note.Flags.Tap },
+        };
 
         public static readonly IReadOnlyDictionary<int, int> c_drumNoteNumLookup = new Dictionary<int, int>()
-    {
-        { 0, (int)Note.DrumPad.Kick      },
-        { 1, (int)Note.DrumPad.Red       },
-        { 2, (int)Note.DrumPad.Yellow    },
-        { 3, (int)Note.DrumPad.Blue      },
-        { 4, (int)Note.DrumPad.Orange    },
-        { 5, (int)Note.DrumPad.Green     },
-    };
+        {
+            { 0, (int)Note.DrumPad.Kick      },
+            { 1, (int)Note.DrumPad.Red       },
+            { 2, (int)Note.DrumPad.Yellow    },
+            { 3, (int)Note.DrumPad.Blue      },
+            { 4, (int)Note.DrumPad.Orange    },
+            { 5, (int)Note.DrumPad.Green     },
+        };
 
         // Default flags for drums notes
         public static readonly IReadOnlyDictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
-    {
-        { (int)Note.DrumPad.Kick      , Note.Flags.None },
-        { (int)Note.DrumPad.Red       , Note.Flags.None },
-        { (int)Note.DrumPad.Yellow    , Note.Flags.None },
-        { (int)Note.DrumPad.Blue      , Note.Flags.None },
-        { (int)Note.DrumPad.Orange    , Note.Flags.None },   // Orange becomes green during 4-lane
-        { (int)Note.DrumPad.Green     , Note.Flags.None },
-    };
+        {
+            { (int)Note.DrumPad.Kick      , Note.Flags.None },
+            { (int)Note.DrumPad.Red       , Note.Flags.None },
+            { (int)Note.DrumPad.Yellow    , Note.Flags.None },
+            { (int)Note.DrumPad.Blue      , Note.Flags.None },
+            { (int)Note.DrumPad.Orange    , Note.Flags.None },   // Orange becomes green during 4-lane
+            { (int)Note.DrumPad.Green     , Note.Flags.None },
+        };
 
         public static readonly IReadOnlyDictionary<int, int> c_ghlNoteNumLookup = new Dictionary<int, int>()
-    {
-        { 0, (int)Note.GHLiveGuitarFret.White1     },
-        { 1, (int)Note.GHLiveGuitarFret.White2       },
-        { 2, (int)Note.GHLiveGuitarFret.White3    },
-        { 3, (int)Note.GHLiveGuitarFret.Black1      },
-        { 4, (int)Note.GHLiveGuitarFret.Black2    },
-        { 8, (int)Note.GHLiveGuitarFret.Black3      },
-        { 7, (int)Note.GHLiveGuitarFret.Open      },
-    };
+        {
+            { 0, (int)Note.GHLiveGuitarFret.White1    },
+            { 1, (int)Note.GHLiveGuitarFret.White2    },
+            { 2, (int)Note.GHLiveGuitarFret.White3    },
+            { 3, (int)Note.GHLiveGuitarFret.Black1    },
+            { 4, (int)Note.GHLiveGuitarFret.Black2    },
+            { 8, (int)Note.GHLiveGuitarFret.Black3    },
+            { 7, (int)Note.GHLiveGuitarFret.Open      },
+        };
 
         public static readonly IReadOnlyDictionary<int, Note.Flags> c_ghlFlagNumLookup = c_guitarFlagNumLookup;
 
         public static readonly IReadOnlyDictionary<string, Song.Difficulty> c_trackNameToTrackDifficultyLookup = new Dictionary<string, Song.Difficulty>()
-    {
-        { "Easy",   Song.Difficulty.Easy    },
-        { "Medium", Song.Difficulty.Medium  },
-        { "Hard",   Song.Difficulty.Hard    },
-        { "Expert", Song.Difficulty.Expert  },
-    };
+        {
+            { "Easy",   Song.Difficulty.Easy    },
+            { "Medium", Song.Difficulty.Medium  },
+            { "Hard",   Song.Difficulty.Hard    },
+            { "Expert", Song.Difficulty.Expert  },
+        };
 
         public static readonly IReadOnlyDictionary<string, Song.Instrument> c_instrumentStrToEnumLookup = new Dictionary<string, Song.Instrument>()
-    {
-        { "Single",         Song.Instrument.Guitar },
-        { "DoubleGuitar",   Song.Instrument.GuitarCoop },
-        { "DoubleBass",     Song.Instrument.Bass },
-        { "DoubleRhythm",   Song.Instrument.Rhythm },
-        { "Drums",          Song.Instrument.Drums },
-        { "Keyboard",       Song.Instrument.Keys },
-        { "GHLGuitar",      Song.Instrument.GHLiveGuitar },
-        { "GHLBass",        Song.Instrument.GHLiveBass },
-    };
+        {
+            { "Single",         Song.Instrument.Guitar },
+            { "DoubleGuitar",   Song.Instrument.GuitarCoop },
+            { "DoubleBass",     Song.Instrument.Bass },
+            { "DoubleRhythm",   Song.Instrument.Rhythm },
+            { "Drums",          Song.Instrument.Drums },
+            { "Keyboard",       Song.Instrument.Keys },
+            { "GHLGuitar",      Song.Instrument.GHLiveGuitar },
+            { "GHLBass",        Song.Instrument.GHLiveBass },
+        };
 
         public static readonly IReadOnlyDictionary<Song.Instrument, Song.Instrument> c_instrumentParsingTypeLookup = new Dictionary<Song.Instrument, Song.Instrument>()
-    {
-        // Other instruments default to loading as a guitar type track
-        { Song.Instrument.Drums,          Song.Instrument.Drums },
-        { Song.Instrument.GHLiveGuitar ,  Song.Instrument.GHLiveGuitar },
-        { Song.Instrument.GHLiveBass ,  Song.Instrument.GHLiveBass },
-    };
+        {
+            // Other instruments default to loading as a guitar type track
+            { Song.Instrument.Drums,          Song.Instrument.Drums },
+            { Song.Instrument.GHLiveGuitar ,  Song.Instrument.GHLiveGuitar },
+            { Song.Instrument.GHLiveBass ,  Song.Instrument.GHLiveBass },
+        };
 
         public static class MetaData
         {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -68,8 +68,6 @@ namespace MoonscraperChartEditor.Song.IO
         // Flags to remove if the corresponding flag is being added
         public static readonly Dictionary<Note.Flags, Note.Flags> c_noteFlagsToRemoveLookup = c_noteBlockingFlagsLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
-        public static readonly Dictionary<int, int> c_drumNoteToSaveNumberLookup = c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
-
         // Default flags for drums notes
         public static readonly Dictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
     {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -313,42 +313,42 @@ namespace MoonscraperChartEditor.Song.IO
             { c_drumsGhostOffset + 5, Ghost },      // Green ghost
         };
 
-            public Note.Flags FlagToAdd { get; } = Note.Flags.None;
-            public Note.Flags BlockingFlag { get; } = Note.Flags.None;
-            public Note.Flags FlagToRemove { get; } = Note.Flags.None;
+            public Note.Flags flagToAdd { get; } = Note.Flags.None;
+            public Note.Flags blockingFlag { get; } = Note.Flags.None;
+            public Note.Flags flagToRemove { get; } = Note.Flags.None;
 
             public NoteFlagPriority(Note.Flags flag)
             {
-                FlagToAdd = flag;
+                flagToAdd = flag;
 
                 Note.Flags blockingFlag;
-                if (c_noteBlockingFlagsLookup.TryGetValue(FlagToAdd, out blockingFlag))
+                if (c_noteBlockingFlagsLookup.TryGetValue(flagToAdd, out blockingFlag))
                 {
-                    BlockingFlag = blockingFlag;
+                    this.blockingFlag = blockingFlag;
                 }
 
                 Note.Flags flagToRemove;
-                if (c_noteFlagsToRemoveLookup.TryGetValue(FlagToAdd, out flagToRemove))
+                if (c_noteFlagsToRemoveLookup.TryGetValue(flagToAdd, out flagToRemove))
                 {
-                    FlagToRemove = flagToRemove;
+                    this.flagToRemove = flagToRemove;
                 }
             }
 
             public bool TryApplyToNote(Note note)
             {
                 // Don't add if the flag to be added is lower-priority than a conflicting, already-added flag
-                if (BlockingFlag != Note.Flags.None && note.flags.HasFlag(BlockingFlag))
+                if (blockingFlag != Note.Flags.None && note.flags.HasFlag(blockingFlag))
                 {
                     return false;
                 }
 
                 // Flag can be added without issue
-                note.flags |= FlagToAdd;
+                note.flags |= flagToAdd;
 
                 // Remove flags that are lower-priority than the added flag
-                if (FlagToRemove != Note.Flags.None && note.flags.HasFlag(FlagToRemove))
+                if (flagToRemove != Note.Flags.None && note.flags.HasFlag(flagToRemove))
                 {
-                    note.flags &= ~FlagToRemove;
+                    note.flags &= ~flagToRemove;
                 }
 
                 return true;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -58,16 +58,6 @@ namespace MoonscraperChartEditor.Song.IO
         { 5, (int)Note.DrumPad.Green     },
     };
 
-        // Flags to skip adding if the corresponding flag is already present
-        public static readonly IReadOnlyDictionary<Note.Flags, Note.Flags> c_noteBlockingFlagsLookup = new Dictionary<Note.Flags, Note.Flags>()
-    {
-        { Note.Flags.Forced, Note.Flags.Tap },
-        { Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent },
-    };
-
-        // Flags to remove if the corresponding flag is being added
-        public static readonly IReadOnlyDictionary<Note.Flags, Note.Flags> c_noteFlagsToRemoveLookup = c_noteBlockingFlagsLookup.ToDictionary((i) => i.Value, (i) => i.Key);
-
         // Default flags for drums notes
         public static readonly IReadOnlyDictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
     {
@@ -243,6 +233,16 @@ namespace MoonscraperChartEditor.Song.IO
 
         public class NoteFlagPriority
         {
+            // Flags to skip adding if the corresponding flag is already present
+            private static readonly IReadOnlyDictionary<Note.Flags, Note.Flags> c_noteBlockingFlagsLookup = new Dictionary<Note.Flags, Note.Flags>()
+            {
+                { Note.Flags.Forced, Note.Flags.Tap },
+                { Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent },
+            };
+
+            // Flags to remove if the corresponding flag is being added
+            private static readonly IReadOnlyDictionary<Note.Flags, Note.Flags> c_noteFlagsToRemoveLookup = c_noteBlockingFlagsLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+
             public static readonly NoteFlagPriority Forced = new NoteFlagPriority(Note.Flags.Forced);
             public static readonly NoteFlagPriority Tap = new NoteFlagPriority(Note.Flags.Tap);
             public static readonly NoteFlagPriority InstrumentPlus = new NoteFlagPriority(Note.Flags.InstrumentPlus);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -250,6 +250,16 @@ namespace MoonscraperChartEditor.Song.IO
             public static readonly NoteFlagPriority Accent = new NoteFlagPriority(Note.Flags.ProDrums_Accent);
             public static readonly NoteFlagPriority Ghost = new NoteFlagPriority(Note.Flags.ProDrums_Ghost);
 
+            private static readonly IReadOnlyList<NoteFlagPriority> priorities = new List<NoteFlagPriority>()
+            {
+                Forced,
+                Tap,
+                InstrumentPlus,
+                Cymbal,
+                Accent,
+                Ghost,
+            };
+
             public Note.Flags flagToAdd { get; } = Note.Flags.None;
             public Note.Flags blockingFlag { get; } = Note.Flags.None;
             public Note.Flags flagToRemove { get; } = Note.Flags.None;
@@ -288,6 +298,50 @@ namespace MoonscraperChartEditor.Song.IO
                     note.flags &= ~flagToRemove;
                 }
 
+                return true;
+            }
+
+            public bool AreFlagsValid(Note.Flags flags)
+            {
+                if (flagToAdd == Note.Flags.None)
+                {
+                    // No flag to validate against
+                    return true;
+                }
+
+                if (blockingFlag != Note.Flags.None)
+                {
+                    if (flags.HasFlag(blockingFlag) && flags.HasFlag(flagToAdd))
+                    {
+                        // Note has conflicting flags
+                        return false;
+                    }
+                }
+
+                if (flagToRemove != Note.Flags.None)
+                {
+                    if (flags.HasFlag(flagToAdd) && flags.HasFlag(flagToRemove))
+                    {
+                        // Note has conflicting flags
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public static bool AreFlagsValidForAll(Note.Flags flags, out NoteFlagPriority invalidPriority)
+            {
+                foreach (var priority in priorities)
+                {
+                    if (!priority.AreFlagsValid(flags))
+                    {
+                        invalidPriority = priority;
+                        return false;
+                    }
+                }
+
+                invalidPriority = null;
                 return true;
             }
         }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartIOHelper.cs
@@ -70,26 +70,6 @@ namespace MoonscraperChartEditor.Song.IO
 
         public static readonly Dictionary<int, int> c_drumNoteToSaveNumberLookup = c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
-        public static readonly Dictionary<int, Note.Flags> c_drumFlagNumLookup = new Dictionary<int, Note.Flags>()
-    {
-        { c_proDrumsOffset + 2, Note.Flags.ProDrums_Cymbal },       // Yellow save num from c_drumNoteNumLookup
-        { c_proDrumsOffset + 3, Note.Flags.ProDrums_Cymbal },       // Blue save num from c_drumNoteNumLookup
-        { c_proDrumsOffset + 4, Note.Flags.ProDrums_Cymbal },       // Orange (Green in 4-lane) save num from c_drumNoteNumLookup
-        { c_instrumentPlusOffset, Note.Flags.InstrumentPlus },      // Double Kick
-
-        { c_drumsAccentOffset + 1, Note.Flags.ProDrums_Accent },    // Red accent
-        { c_drumsAccentOffset + 2, Note.Flags.ProDrums_Accent },    // Yellow accent
-        { c_drumsAccentOffset + 3, Note.Flags.ProDrums_Accent },    // Blue accent
-        { c_drumsAccentOffset + 4, Note.Flags.ProDrums_Accent },    // Orange accent
-        { c_drumsAccentOffset + 5, Note.Flags.ProDrums_Accent },    // Green accent
-
-        { c_drumsGhostOffset + 1, Note.Flags.ProDrums_Ghost },      // Red ghost
-        { c_drumsGhostOffset + 2, Note.Flags.ProDrums_Ghost },      // Yellow ghost
-        { c_drumsGhostOffset + 3, Note.Flags.ProDrums_Ghost },      // Blue ghost
-        { c_drumsGhostOffset + 4, Note.Flags.ProDrums_Ghost },      // Orange ghost
-        { c_drumsGhostOffset + 5, Note.Flags.ProDrums_Ghost },      // Green ghost
-    };
-
         // Default flags for drums notes
         public static readonly Dictionary<int, Note.Flags> c_drumNoteDefaultFlagsLookup = new Dictionary<int, Note.Flags>()
     {
@@ -289,29 +269,6 @@ namespace MoonscraperChartEditor.Song.IO
             public static readonly NoteFlagPriority Cymbal = new NoteFlagPriority(Note.Flags.ProDrums_Cymbal);
             public static readonly NoteFlagPriority Accent = new NoteFlagPriority(Note.Flags.ProDrums_Accent);
             public static readonly NoteFlagPriority Ghost = new NoteFlagPriority(Note.Flags.ProDrums_Ghost);
-
-            public static readonly IReadOnlyDictionary<int, NoteFlagPriority> GuitarNoteToPriorityLookup = new Dictionary<int, NoteFlagPriority>()
-        {
-            { 5, Forced },    // Forced note marker
-            { 6, Tap    },    // Tap note marker
-        };
-
-            public static readonly IReadOnlyDictionary<int, NoteFlagPriority> GhlGuitarNoteToPriorityLookup = GuitarNoteToPriorityLookup;
-
-            public static readonly IReadOnlyDictionary<int, NoteFlagPriority> DrumsNoteToPriorityLookup = new Dictionary<int, NoteFlagPriority>()
-        {
-            { c_drumsAccentOffset + 1, Accent },    // Red accent
-            { c_drumsAccentOffset + 2, Accent },    // Yellow accent
-            { c_drumsAccentOffset + 3, Accent },    // Blue accent
-            { c_drumsAccentOffset + 4, Accent },    // Orange accent
-            { c_drumsAccentOffset + 5, Accent },    // Green accent
-
-            { c_drumsGhostOffset + 1, Ghost },      // Red ghost
-            { c_drumsGhostOffset + 2, Ghost },      // Yellow ghost
-            { c_drumsGhostOffset + 3, Ghost },      // Blue ghost
-            { c_drumsGhostOffset + 4, Ghost },      // Orange ghost
-            { c_drumsGhostOffset + 5, Ghost },      // Green ghost
-        };
 
             public Note.Flags flagToAdd { get; } = Note.Flags.None;
             public Note.Flags blockingFlag { get; } = Note.Flags.None;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -55,7 +55,7 @@ namespace MoonscraperChartEditor.Song.IO
 
         delegate void NoteEventProcessFn(in NoteProcessParams noteProcessParams);
 
-        // These dictionaries map the NoteNumber of each midi note event to a specific function of how to process them
+        // These dictionaries map the number of a note event to a specific function of how to process them
         static readonly IReadOnlyDictionary<int, NoteEventProcessFn> GuitarChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
         {
             { 0, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.GuitarFret.Green); }},

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -902,7 +902,7 @@ namespace MoonscraperChartEditor.Song.IO
         {
             if (!flagData.TryApplyToNote(note))
             {
-                Debug.LogWarning($"Could not apply flag {flagData.FlagToAdd} to a note. It was blocked by existing flag {flagData.BlockingFlag}.");
+                Debug.LogWarning($"Could not apply flag {flagData.flagToAdd} to a note. It was blocked by existing flag {flagData.blockingFlag}.");
             }
         }
     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -92,6 +92,7 @@ namespace MoonscraperChartEditor.Song.IO
                 ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, NoteFlagPriority.Cymbal);
             } },
 
+            // { ChartIOHelper.c_drumsAccentOffset + 0, ... }  // Reserved for kick accents, if they should ever be a thing
             { ChartIOHelper.c_drumsAccentOffset + 1, (in NoteProcessParams noteProcessParams) => {
                 ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Red, NoteFlagPriority.Accent);
             } },
@@ -108,6 +109,7 @@ namespace MoonscraperChartEditor.Song.IO
                 ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Green, NoteFlagPriority.Accent);
             } },
 
+            // { ChartIOHelper.c_drumsGhostOffset + 0, ... }  // Reserved for kick ghosts, if they should ever be a thing
             { ChartIOHelper.c_drumsGhostOffset + 1, (in NoteProcessParams noteProcessParams) => {
                 ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Red, NoteFlagPriority.Ghost);
             } },

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 // Chart file format specifications- https://docs.google.com/document/d/1v2v0U-9HQ5qHeccpExDOLJ5CMPZZ3QytPmAG5WF0Kzs/edit?usp=sharing
@@ -53,7 +53,7 @@ namespace MoonscraperChartEditor.Song.IO
         delegate void NoteEventProcessFn(in NoteProcessParams noteProcessParams);
 
         // These dictionaries map the NoteNumber of each midi note event to a specific function of how to process them
-        static readonly Dictionary<int, NoteEventProcessFn> GuitarChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
+        static readonly IReadOnlyDictionary<int, NoteEventProcessFn> GuitarChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
         {
             { 0, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.GuitarFret.Green); }},
             { 1, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.GuitarFret.Red); }},
@@ -66,7 +66,7 @@ namespace MoonscraperChartEditor.Song.IO
             { 6, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsChordFlag(noteProcessParams, Note.Flags.Tap); }},
         };
 
-        static readonly Dictionary<int, NoteEventProcessFn> DrumsChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
+        static readonly IReadOnlyDictionary<int, NoteEventProcessFn> DrumsChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
         {
             { 0, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Kick); }},
             { 1, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Red); }},
@@ -122,7 +122,7 @@ namespace MoonscraperChartEditor.Song.IO
             } },
         };
 
-        static readonly Dictionary<int, NoteEventProcessFn> GhlChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
+        static readonly IReadOnlyDictionary<int, NoteEventProcessFn> GhlChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
         {
             { 0, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.GHLiveGuitarFret.White1); }},
             { 1, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.GHLiveGuitarFret.White2); }},
@@ -641,7 +641,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             chart.SetCapacity(data.Count);
 
-            Dictionary<int, NoteEventProcessFn> noteProcessDict = GetNoteProcessDict(chart.gameMode);
+            var noteProcessDict = GetNoteProcessDict(chart.gameMode);
 
             try
             {
@@ -803,7 +803,7 @@ namespace MoonscraperChartEditor.Song.IO
             }
         }
 
-        static Dictionary<int, NoteEventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
+        static IReadOnlyDictionary<int, NoteEventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
         {
             switch (gameMode)
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -69,7 +69,61 @@ namespace MoonscraperChartEditor.Song.IO
             { 6, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsChordFlag(noteProcessParams, NoteFlagPriority.Tap); }},
         };
 
-        static readonly IReadOnlyDictionary<int, NoteEventProcessFn> DrumsChartNoteNumberToProcessFnMap = BuildDrumsChartNoteNumberToProcessFnMap();
+        static readonly IReadOnlyDictionary<int, NoteEventProcessFn> DrumsChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
+        {
+            { 0, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Kick); }},
+            { 1, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Red); }},
+            { 2, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Yellow); }},
+            { 3, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Blue); }},
+            { 4, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Orange); }},
+            { 5, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Green); }},
+
+            { ChartIOHelper.c_instrumentPlusOffset, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Kick, Note.Flags.DoubleKick);
+            } },
+
+            { ChartIOHelper.c_proDrumsOffset + 2, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Yellow, NoteFlagPriority.Cymbal);
+            } },
+            { ChartIOHelper.c_proDrumsOffset + 3, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Blue, NoteFlagPriority.Cymbal);
+            } },
+            { ChartIOHelper.c_proDrumsOffset + 4, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, NoteFlagPriority.Cymbal);
+            } },
+
+            { ChartIOHelper.c_drumsAccentOffset + 1, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Red, NoteFlagPriority.Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 2, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Yellow, NoteFlagPriority.Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 3, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Blue, NoteFlagPriority.Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 4, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, NoteFlagPriority.Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 5, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Green, NoteFlagPriority.Accent);
+            } },
+
+            { ChartIOHelper.c_drumsGhostOffset + 1, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Red, NoteFlagPriority.Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 2, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Yellow, NoteFlagPriority.Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 3, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Blue, NoteFlagPriority.Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 4, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, NoteFlagPriority.Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 5, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Green, NoteFlagPriority.Ghost);
+            } },
+        };
 
         static readonly IReadOnlyDictionary<int, NoteEventProcessFn> GhlChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()
         {
@@ -84,72 +138,6 @@ namespace MoonscraperChartEditor.Song.IO
             { 5, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsChordFlag(noteProcessParams, NoteFlagPriority.Forced); }},
             { 6, (in NoteProcessParams noteProcessParams) => { ProcessNoteOnEventAsChordFlag(noteProcessParams, NoteFlagPriority.Tap); }},
         };
-
-        static IReadOnlyDictionary<int, NoteEventProcessFn> BuildDrumsChartNoteNumberToProcessFnMap()
-        {
-            var processFnMap = new Dictionary<int, NoteEventProcessFn>()
-        {
-            { ChartIOHelper.c_instrumentPlusOffset, (in NoteProcessParams noteProcessParams) => {
-                ProcessNoteOnEventAsNote(noteProcessParams, (int)Note.DrumPad.Kick, Note.Flags.DoubleKick);
-            } },
-        };
-
-            Dictionary<Note.DrumPad, int> DrumPadToChartKey = new Dictionary<Note.DrumPad, int>()
-        {
-            { Note.DrumPad.Kick, 0 },
-            { Note.DrumPad.Red, 1 },
-            { Note.DrumPad.Yellow, 2 },
-            { Note.DrumPad.Blue, 3 },
-            { Note.DrumPad.Orange, 4 },
-            { Note.DrumPad.Green, 5 },
-        };
-
-            foreach (var pad in EnumX<Note.DrumPad>.Values)
-            {
-                int padKey;
-                if (DrumPadToChartKey.TryGetValue(pad, out padKey))
-                {
-                    // Get default flags
-                    Note.Flags defaultFlags;
-                    if (!ChartIOHelper.c_drumNoteDefaultFlagsLookup.TryGetValue(padKey, out defaultFlags))
-                    {
-                        defaultFlags = Note.Flags.None;
-                    }
-
-                    // Notes
-                    processFnMap.Add(padKey, (in NoteProcessParams noteProcessParams) =>
-                    {
-                        ProcessNoteOnEventAsNote(noteProcessParams, (int)pad);
-                    });
-
-                    // Flag toggles
-                    Action<int> AddFlagToggle = (int key) => {
-                        NoteFlagPriority flagData;
-                        if (NoteFlagPriority.DrumsNoteToPriorityLookup.TryGetValue(key, out flagData))
-                        {
-                            processFnMap.Add(key, (in NoteProcessParams noteProcessParams) =>
-                            {
-                                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)pad, flagData);
-                            });
-                        }
-                    };
-
-                    // Cymbals
-                    int cymbalKey = padKey + ChartIOHelper.c_proDrumsOffset;
-                    AddFlagToggle(cymbalKey);
-
-                    // Accents
-                    int accentKey = padKey + ChartIOHelper.c_drumsAccentOffset;
-                    AddFlagToggle(accentKey);
-
-                    // Ghosts
-                    int ghostKey = padKey + ChartIOHelper.c_drumsGhostOffset;
-                    AddFlagToggle(ghostKey);
-                }
-            }
-
-            return processFnMap;
-        }
 
         public static Song ReadChart(string filepath)
         {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -88,6 +88,38 @@ namespace MoonscraperChartEditor.Song.IO
             { ChartIOHelper.c_proDrumsOffset + 4, (in NoteProcessParams noteProcessParams) => {
                 ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, Note.Flags.ProDrums_Cymbal);
             } },
+
+            { ChartIOHelper.c_drumsAccentOffset + 1, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Red, Note.Flags.ProDrums_Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 2, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Yellow, Note.Flags.ProDrums_Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 3, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Blue, Note.Flags.ProDrums_Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 4, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, Note.Flags.ProDrums_Accent);
+            } },
+            { ChartIOHelper.c_drumsAccentOffset + 5, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Green, Note.Flags.ProDrums_Accent);
+            } },
+
+            { ChartIOHelper.c_drumsGhostOffset + 1, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Red, Note.Flags.ProDrums_Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 2, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Yellow, Note.Flags.ProDrums_Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 3, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Blue, Note.Flags.ProDrums_Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 4, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Orange, Note.Flags.ProDrums_Ghost);
+            } },
+            { ChartIOHelper.c_drumsGhostOffset + 5, (in NoteProcessParams noteProcessParams) => {
+                ProcessNoteOnEventAsNoteFlagToggle(noteProcessParams, (int)Note.DrumPad.Green, Note.Flags.ProDrums_Ghost);
+            } },
         };
 
         static readonly Dictionary<int, NoteEventProcessFn> GhlChartNoteNumberToProcessFnMap = new Dictionary<int, NoteEventProcessFn>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartReader.cs
@@ -881,7 +881,7 @@ namespace MoonscraperChartEditor.Song.IO
                     Note note = chart.notes[i];
                     if (note.rawNote == rawNote)
                     {
-                        note.flags ^= flag;
+                        AddNoteFlag(note, flag);
                     }
                 }
             }
@@ -891,7 +891,27 @@ namespace MoonscraperChartEditor.Song.IO
         {
             for (int i = index; i < index + length; ++i)
             {
-                notes[i].flags = notes[i].flags | flag;
+                AddNoteFlag(notes[i], flag);
+            }
+        }
+
+        static void AddNoteFlag(Note note, Note.Flags flag)
+        {
+            // Don't add if the flag to be added is lower-priority than a conflicting, already-added flag
+            Note.Flags prioritizedFlag;
+            if (ChartIOHelper.c_noteFlagIgnoreLookup.TryGetValue(flag, out prioritizedFlag))
+            {
+                if ((note.flags & prioritizedFlag) != Note.Flags.None)
+                    return;
+            }
+
+            note.flags |= flag;
+
+            // Remove any flags that the newly-added flag should override
+            Note.Flags flagToRemove;
+            if (ChartIOHelper.c_noteFlagOverrideLookup.TryGetValue(flag, out flagToRemove))
+            {
+                note.flags &= ~flagToRemove;
             }
         }
     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -41,24 +41,24 @@ namespace MoonscraperChartEditor.Song.IO
         public static readonly IReadOnlyDictionary<int, int> c_drumNoteToSaveNumberLookup = ChartIOHelper.c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
         public static readonly IReadOnlyDictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
-    {
-        // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsAccentOffset + 0 },  // Reserved for kick accents, if those ever become a thing
-        { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsAccentOffset + 1 },
-        { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsAccentOffset + 2 },
-        { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsAccentOffset + 3 },
-        { (int)Note.DrumPad.Orange    , ChartIOHelper.c_drumsAccentOffset + 4 },
-        { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsAccentOffset + 5 },
-    };
+        {
+            // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsAccentOffset + 0 },  // Reserved for kick accents, if those ever become a thing
+            { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsAccentOffset + 1 },
+            { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsAccentOffset + 2 },
+            { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsAccentOffset + 3 },
+            { (int)Note.DrumPad.Orange    , ChartIOHelper.c_drumsAccentOffset + 4 },
+            { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsAccentOffset + 5 },
+        };
 
         public static readonly IReadOnlyDictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
-    {
-        // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsGhostOffset + 0 },  // Reserved for kick ghosts, if those ever become a thing
-        { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsGhostOffset + 1 },
-        { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsGhostOffset + 2 },
-        { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsGhostOffset + 3 },
-        { (int)Note.DrumPad.Orange    , ChartIOHelper.c_drumsGhostOffset + 4 },
-        { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsGhostOffset + 5 },
-    };
+        {
+            // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsGhostOffset + 0 },  // Reserved for kick ghosts, if those ever become a thing
+            { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsGhostOffset + 1 },
+            { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsGhostOffset + 2 },
+            { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsGhostOffset + 3 },
+            { (int)Note.DrumPad.Orange    , ChartIOHelper.c_drumsGhostOffset + 4 },
+            { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsGhostOffset + 5 },
+        };
 
         delegate void WriteAudioStreamSaveString(Song.AudioInstrument audio, string saveFormat);
 
@@ -91,15 +91,15 @@ namespace MoonscraperChartEditor.Song.IO
         }
         delegate void AppendSongObjectData(SongObject so, in SongObjectWriteParameters writeParameters, StringBuilder output);
         static readonly Dictionary<SongObject.ID, AppendSongObjectData> c_songObjectWriteFnLookup = new Dictionary<SongObject.ID, AppendSongObjectData>()
-    {
-        { SongObject.ID.BPM, AppendBpmData },
-        { SongObject.ID.TimeSignature, AppendTsData },
-        { SongObject.ID.Event, AppendEventData },
-        { SongObject.ID.Section, AppendSectionData },
-        { SongObject.ID.Starpower, AppendStarpowerData },
-        { SongObject.ID.ChartEvent, AppendChartEventData },
-        { SongObject.ID.Note, AppendNoteData },
-    };
+        {
+            { SongObject.ID.BPM, AppendBpmData },
+            { SongObject.ID.TimeSignature, AppendTsData },
+            { SongObject.ID.Event, AppendEventData },
+            { SongObject.ID.Section, AppendSectionData },
+            { SongObject.ID.Starpower, AppendStarpowerData },
+            { SongObject.ID.ChartEvent, AppendChartEventData },
+            { SongObject.ID.Note, AppendNoteData },
+        };
 
         public void Write(Song song, ExportOptions exportOptions, out ErrorReport errorReport)
         {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -541,16 +541,16 @@ namespace MoonscraperChartEditor.Song.IO
                     // Only need to get the flags of one note of a chord
                     if (note.next == null || (note.next != null && note.next.tick != note.tick))
                     {
-                        // Flag overrides
+#if UNITY_EDITOR
+                        // Verify that there are no conflicting flags
                         foreach (var flags in ChartIOHelper.c_noteFlagOverrideLookup)
                         {
-                            // Test for higher-priority flag
-                            if ((note.flags & flags.Key) != Note.Flags.None)
+                            if ((noteFlags & flags.Key) != Note.Flags.None && (noteFlags & flags.Value) != Note.Flags.None)
                             {
-                                // Remove lower-priority flag
-                                note.flags &= ~flags.Key;
+                                Debug.LogError($"Conflicting flags found during export. Higher priority: {flags.Key}, lower priority: {flags.Value}");
                             }
                         }
+#endif
 
                         // Write out forced flag
                         {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -38,6 +38,7 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly Dictionary<int, int> c_guitarNoteToSaveNumberLookup = ChartIOHelper.c_guitarNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
         static readonly Dictionary<int, int> c_ghlNoteToSaveNumberLookup = ChartIOHelper.c_ghlNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
         static readonly Dictionary<Note.Flags, int> c_guitarFlagToNumLookup = ChartIOHelper.c_guitarFlagNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        public static readonly Dictionary<int, int> c_drumNoteToSaveNumberLookup = ChartIOHelper.c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
         public static readonly Dictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
     {
@@ -380,7 +381,7 @@ namespace MoonscraperChartEditor.Song.IO
 
         static int GetDrumsSaveNoteNumber(Note note)
         {
-            return GetSaveNoteNumber((int)note.drumPad, ChartIOHelper.c_drumNoteToSaveNumberLookup);
+            return GetSaveNoteNumber((int)note.drumPad, c_drumNoteToSaveNumberLookup);
         }
 
         static int GetGHLSaveNoteNumber(Note note)
@@ -636,7 +637,7 @@ namespace MoonscraperChartEditor.Song.IO
                     // Write out cymbal flag for each note
                     int writeValue = ChartIOHelper.c_proDrumsOffset;
                     int noteOffset;
-                    if (!ChartIOHelper.c_drumNoteToSaveNumberLookup.TryGetValue(note.rawNote, out noteOffset))
+                    if (!c_drumNoteToSaveNumberLookup.TryGetValue(note.rawNote, out noteOffset))
                     {
                         throw new Exception("Cannot find pro drum note offset for note " + note.drumPad.ToString());
                     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -541,10 +541,15 @@ namespace MoonscraperChartEditor.Song.IO
                     // Only need to get the flags of one note of a chord
                     if (note.next == null || (note.next != null && note.next.tick != note.tick))
                     {
-                        Note.Flags flagsToIgnore;
-                        if (!ChartIOHelper.c_drumNoteDefaultFlagsLookup.TryGetValue(note.rawNote, out flagsToIgnore))
+                        // Flag overrides
+                        foreach (var flags in ChartIOHelper.c_noteFlagOverrideLookup)
                         {
-                            flagsToIgnore = Note.Flags.None;
+                            // Test for higher-priority flag
+                            if ((note.flags & flags.Key) != Note.Flags.None)
+                            {
+                                // Remove lower-priority flag
+                                note.flags &= ~flags.Key;
+                            }
                         }
 
                         // Write out forced flag

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -32,15 +32,15 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly string s_chartHeaderTrackFormat = "[{0}{1}]" + Globals.LINE_ENDING + "{{" + Globals.LINE_ENDING;
 
         // Bi-directional dict lookups
-        static readonly Dictionary<Song.Instrument, string> c_instrumentToStrLookup = ChartIOHelper.c_instrumentStrToEnumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
-        static readonly Dictionary<Song.Difficulty, string> c_difficultyToTrackNameLookup = ChartIOHelper.c_trackNameToTrackDifficultyLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        static readonly IReadOnlyDictionary<Song.Instrument, string> c_instrumentToStrLookup = ChartIOHelper.c_instrumentStrToEnumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        static readonly IReadOnlyDictionary<Song.Difficulty, string> c_difficultyToTrackNameLookup = ChartIOHelper.c_trackNameToTrackDifficultyLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
-        static readonly Dictionary<int, int> c_guitarNoteToSaveNumberLookup = ChartIOHelper.c_guitarNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
-        static readonly Dictionary<int, int> c_ghlNoteToSaveNumberLookup = ChartIOHelper.c_ghlNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
-        static readonly Dictionary<Note.Flags, int> c_guitarFlagToNumLookup = ChartIOHelper.c_guitarFlagNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
-        public static readonly Dictionary<int, int> c_drumNoteToSaveNumberLookup = ChartIOHelper.c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        static readonly IReadOnlyDictionary<int, int> c_guitarNoteToSaveNumberLookup = ChartIOHelper.c_guitarNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        static readonly IReadOnlyDictionary<int, int> c_ghlNoteToSaveNumberLookup = ChartIOHelper.c_ghlNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        static readonly IReadOnlyDictionary<Note.Flags, int> c_guitarFlagToNumLookup = ChartIOHelper.c_guitarFlagNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
+        public static readonly IReadOnlyDictionary<int, int> c_drumNoteToSaveNumberLookup = ChartIOHelper.c_drumNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
-        public static readonly Dictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
+        public static readonly IReadOnlyDictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
     {
         // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsAccentOffset + 0 },  // Reserved for kick accents, if those ever become a thing
         { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsAccentOffset + 1 },
@@ -50,7 +50,7 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsAccentOffset + 5 },
     };
 
-        public static readonly Dictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
+        public static readonly IReadOnlyDictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
     {
         // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsGhostOffset + 0 },  // Reserved for kick ghosts, if those ever become a thing
         { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsGhostOffset + 1 },
@@ -363,7 +363,7 @@ namespace MoonscraperChartEditor.Song.IO
             return saveString.ToString();
         }
 
-        static int GetSaveNoteNumber(int note, Dictionary<int, int> lookupDict)
+        static int GetSaveNoteNumber(int note, IReadOnlyDictionary<int, int> lookupDict)
         {
             int noteNumber;
             if (!lookupDict.TryGetValue(note, out noteNumber))

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 // Chart file format specifications- https://docs.google.com/document/d/1v2v0U-9HQ5qHeccpExDOLJ5CMPZZ3QytPmAG5WF0Kzs/edit?usp=sharing
@@ -579,9 +579,38 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
 
-                // Write out cymbal flag for each note
                 if (writeParameters.instrument == Song.Instrument.Drums)
                 {
+                    // Write out accent/ghost flags
+                    {
+                        Note.Flags flagToTest = Note.Flags.ProDrums_Accent;
+                        if ((noteFlags & flagToTest) != 0)
+                        {
+                            int value;
+                            if (ChartIOHelper.c_drumNoteAccentSaveLookup.TryGetValue(note.rawNote, out value))
+                            {
+                                output.Append(Globals.LINE_ENDING);
+                                output.Append(Globals.TABSPACE + writeParameters.scaledTick);
+                                output.AppendFormat(s_noteFormat, value, 0);
+                            }
+                        }
+                        else
+                        {
+                            flagToTest = Note.Flags.ProDrums_Ghost;
+                            if ((noteFlags & flagToTest) != 0)
+                            {
+                                int value;
+                                if (ChartIOHelper.c_drumNoteGhostSaveLookup.TryGetValue(note.rawNote, out value))
+                                {
+                                    output.Append(Globals.LINE_ENDING);
+                                    output.Append(Globals.TABSPACE + writeParameters.scaledTick);
+                                    output.AppendFormat(s_noteFormat, value, 0);
+                                }
+                            }
+                        }
+                    }
+
+                    // Write out cymbal flag for each note
                     int writeValue = ChartIOHelper.c_proDrumsOffset;
                     int noteOffset;
                     if (!ChartIOHelper.c_drumNoteToSaveNumberLookup.TryGetValue(note.rawNote, out noteOffset))

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -39,6 +39,24 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly Dictionary<int, int> c_ghlNoteToSaveNumberLookup = ChartIOHelper.c_ghlNoteNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
         static readonly Dictionary<Note.Flags, int> c_guitarFlagToNumLookup = ChartIOHelper.c_guitarFlagNumLookup.ToDictionary((i) => i.Value, (i) => i.Key);
 
+        public static readonly Dictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
+    {
+        { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsAccentOffset + 1 },
+        { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsAccentOffset + 2 },
+        { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsAccentOffset + 3 },
+        { (int)Note.DrumPad.Orange    , ChartIOHelper.c_drumsAccentOffset + 4 },
+        { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsAccentOffset + 5 },
+    };
+
+        public static readonly Dictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
+    {
+        { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsGhostOffset + 1 },
+        { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsGhostOffset + 2 },
+        { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsGhostOffset + 3 },
+        { (int)Note.DrumPad.Orange    , ChartIOHelper.c_drumsGhostOffset + 4 },
+        { (int)Note.DrumPad.Green     , ChartIOHelper.c_drumsGhostOffset + 5 },
+    };
+
         delegate void WriteAudioStreamSaveString(Song.AudioInstrument audio, string saveFormat);
 
         public class ErrorReport
@@ -591,7 +609,7 @@ namespace MoonscraperChartEditor.Song.IO
                         if (noteFlags.HasFlag(Note.Flags.ProDrums_Accent))
                         {
                             int value;
-                            if (ChartIOHelper.c_drumNoteAccentSaveLookup.TryGetValue(note.rawNote, out value))
+                            if (c_drumNoteAccentSaveLookup.TryGetValue(note.rawNote, out value))
                             {
                                 output.Append(Globals.LINE_ENDING);
                                 output.Append(Globals.TABSPACE + writeParameters.scaledTick);
@@ -603,7 +621,7 @@ namespace MoonscraperChartEditor.Song.IO
                             if (noteFlags.HasFlag(Note.Flags.ProDrums_Ghost))
                             {
                                 int value;
-                                if (ChartIOHelper.c_drumNoteGhostSaveLookup.TryGetValue(note.rawNote, out value))
+                                if (c_drumNoteGhostSaveLookup.TryGetValue(note.rawNote, out value))
                                 {
                                     output.Append(Globals.LINE_ENDING);
                                     output.Append(Globals.TABSPACE + writeParameters.scaledTick);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -41,6 +41,7 @@ namespace MoonscraperChartEditor.Song.IO
 
         public static readonly Dictionary<int, int> c_drumNoteAccentSaveLookup = new Dictionary<int, int>()
     {
+        // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsAccentOffset + 0 },  // Reserved for kick accents, if those ever become a thing
         { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsAccentOffset + 1 },
         { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsAccentOffset + 2 },
         { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsAccentOffset + 3 },
@@ -50,6 +51,7 @@ namespace MoonscraperChartEditor.Song.IO
 
         public static readonly Dictionary<int, int> c_drumNoteGhostSaveLookup = new Dictionary<int, int>()
     {
+        // { (int)Note.DrumPad.Kick       , ChartIOHelper.c_drumsGhostOffset + 0 },  // Reserved for kick ghosts, if those ever become a thing
         { (int)Note.DrumPad.Red       , ChartIOHelper.c_drumsGhostOffset + 1 },
         { (int)Note.DrumPad.Yellow    , ChartIOHelper.c_drumsGhostOffset + 2 },
         { (int)Note.DrumPad.Blue      , ChartIOHelper.c_drumsGhostOffset + 3 },

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -525,7 +525,7 @@ namespace MoonscraperChartEditor.Song.IO
                 fretNumber = note.rawNote;
 
             // Write out the instrument+ version of the note if applicable
-            if (writeParameters.exportOptions.forced && (note.flags & Note.Flags.DoubleKick) != 0 && NoteFunctions.AllowedToBeDoubleKick(note, difficulty))
+            if (writeParameters.exportOptions.forced && note.flags.HasFlag(Note.Flags.DoubleKick) && NoteFunctions.AllowedToBeDoubleKick(note, difficulty))
             {
                 fretNumber += ChartIOHelper.c_instrumentPlusOffset;
             }
@@ -545,7 +545,7 @@ namespace MoonscraperChartEditor.Song.IO
                         // Verify that there are no conflicting flags
                         foreach (var flags in ChartIOHelper.c_noteFlagOverrideLookup)
                         {
-                            if ((noteFlags & flags.Key) != Note.Flags.None && (noteFlags & flags.Value) != Note.Flags.None)
+                            if (noteFlags.HasFlag(flags.Key) && noteFlags.HasFlag(flags.Value))
                             {
                                 Debug.LogError($"Conflicting flags found during export. Higher priority: {flags.Key}, lower priority: {flags.Value}");
                             }
@@ -555,7 +555,7 @@ namespace MoonscraperChartEditor.Song.IO
                         // Write out forced flag
                         {
                             Note.Flags flagToTest = Note.Flags.Forced;
-                            if ((noteFlags & flagToTest) != 0)
+                            if (noteFlags.HasFlag(flagToTest))
                             {
                                 int value;
                                 if (c_guitarFlagToNumLookup.TryGetValue(flagToTest, out value))  // Todo, if different flags have different values for the same flags, we'll need to use different lookups
@@ -570,7 +570,7 @@ namespace MoonscraperChartEditor.Song.IO
                         // Write out tap flag
                         {
                             Note.Flags flagToTest = Note.Flags.Tap;
-                            if (!note.IsOpenNote() && (noteFlags & flagToTest) != 0)
+                            if (!note.IsOpenNote() && noteFlags.HasFlag(flagToTest))
                             {
                                 int value;
                                 if (c_guitarFlagToNumLookup.TryGetValue(flagToTest, out value))  // Todo, if different flags have different values for the same flags, we'll need to use different lookups
@@ -588,8 +588,7 @@ namespace MoonscraperChartEditor.Song.IO
                 {
                     // Write out accent/ghost flags
                     {
-                        Note.Flags flagToTest = Note.Flags.ProDrums_Accent;
-                        if ((noteFlags & flagToTest) != 0)
+                        if (noteFlags.HasFlag(Note.Flags.ProDrums_Accent))
                         {
                             int value;
                             if (ChartIOHelper.c_drumNoteAccentSaveLookup.TryGetValue(note.rawNote, out value))
@@ -601,8 +600,7 @@ namespace MoonscraperChartEditor.Song.IO
                         }
                         else
                         {
-                            flagToTest = Note.Flags.ProDrums_Ghost;
-                            if ((noteFlags & flagToTest) != 0)
+                            if (noteFlags.HasFlag(Note.Flags.ProDrums_Ghost))
                             {
                                 int value;
                                 if (ChartIOHelper.c_drumNoteGhostSaveLookup.TryGetValue(note.rawNote, out value))
@@ -631,8 +629,8 @@ namespace MoonscraperChartEditor.Song.IO
                         defaultFlagsForNote = Note.Flags.None;
                     }
 
-                    bool cymbalByDefault = (defaultFlagsForNote & Note.Flags.ProDrums_Cymbal) != 0;
-                    bool flaggedAsCymbal = (noteFlags & Note.Flags.ProDrums_Cymbal) != 0;
+                    bool cymbalByDefault = defaultFlagsForNote.HasFlag(Note.Flags.ProDrums_Cymbal);
+                    bool flaggedAsCymbal = noteFlags.HasFlag(Note.Flags.ProDrums_Cymbal);
                     bool writeCymbalFlag = cymbalByDefault != flaggedAsCymbal;
 
                     if (writeCymbalFlag && !note.IsOpenNote())

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -564,11 +564,16 @@ namespace MoonscraperChartEditor.Song.IO
                     {
 #if UNITY_EDITOR
                         // Verify that there are no conflicting flags
-                        foreach (var flags in ChartIOHelper.c_noteFlagsToRemoveLookup)
+                        if (!ChartIOHelper.NoteFlagPriority.AreFlagsValidForAll(noteFlags, out var priority))
                         {
-                            if (noteFlags.HasFlag(flags.Key) && noteFlags.HasFlag(flags.Value))
+                            Debug.Assert(priority != null);
+                            if (priority.blockingFlag != Note.Flags.None)
                             {
-                                Debug.LogError($"Conflicting flags found during export. Higher priority: {flags.Key}, lower priority: {flags.Value}");
+                                Debug.LogError($"Conflicting flags found during export. Higher priority: {priority.blockingFlag}, lower priority: {priority.flagToAdd}");
+                            }
+                            else if (priority.flagToRemove != Note.Flags.None)
+                            {
+                                Debug.LogError($"Conflicting flags found during export. Higher priority: {priority.flagToAdd}, lower priority: {priority.flagToRemove}");
                             }
                         }
 #endif

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Chart/ChartWriter.cs
@@ -543,7 +543,7 @@ namespace MoonscraperChartEditor.Song.IO
                     {
 #if UNITY_EDITOR
                         // Verify that there are no conflicting flags
-                        foreach (var flags in ChartIOHelper.c_noteFlagOverrideLookup)
+                        foreach (var flags in ChartIOHelper.c_noteFlagsToRemoveLookup)
                         {
                             if (noteFlags.HasFlag(flags.Key) && noteFlags.HasFlag(flags.Value))
                             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -46,6 +46,9 @@ namespace MoonscraperChartEditor.Song.IO
 
         public const string SECTION_PREFIX_RB2 = "section ";
         public const string SECTION_PREFIX_RB3 = "prc_";
+
+        public const string CHART_DYNAMICS_TEXT = "ENABLE_CHART_DYNAMICS";
+        public const string CHART_DYNAMICS_TEXT_BRACKET = "[ENABLE_CHART_DYNAMICS]";
 
         // Note velocities
         public const byte VELOCITY = 100;             // default note velocity for exporting

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -58,7 +58,7 @@ namespace MoonscraperChartEditor.Song.IO
         public const byte VELOCITY_GHOST = 1;         // fof/ps
 
         // Lookup tables
-        public static readonly Dictionary<Song.Difficulty, int> GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
+        public static readonly IReadOnlyDictionary<Song.Difficulty, int> GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
     {
         { Song.Difficulty.Easy, 60 },
         { Song.Difficulty.Medium, 72 },
@@ -66,7 +66,7 @@ namespace MoonscraperChartEditor.Song.IO
         { Song.Difficulty.Expert, 96 }
     };
 
-        public static readonly Dictionary<Song.Difficulty, int> GHL_GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
+        public static readonly IReadOnlyDictionary<Song.Difficulty, int> GHL_GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
     {
         { Song.Difficulty.Easy, 58 },
         { Song.Difficulty.Medium, 70 },
@@ -74,7 +74,7 @@ namespace MoonscraperChartEditor.Song.IO
         { Song.Difficulty.Expert, 94 }
     };
 
-        public static readonly Dictionary<Song.Difficulty, int> DRUMS_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
+        public static readonly IReadOnlyDictionary<Song.Difficulty, int> DRUMS_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
     {
         { Song.Difficulty.Easy, 60 },
         { Song.Difficulty.Medium, 72 },
@@ -83,13 +83,13 @@ namespace MoonscraperChartEditor.Song.IO
     };
 
         // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring
-        public static readonly Dictionary<Note.DrumPad, int> PAD_TO_CYMBAL_LOOKUP = new Dictionary<Note.DrumPad, int>()
+        public static readonly IReadOnlyDictionary<Note.DrumPad, int> PAD_TO_CYMBAL_LOOKUP = new Dictionary<Note.DrumPad, int>()
     {
         { Note.DrumPad.Yellow, 110 },
         { Note.DrumPad.Blue, 111 },
         { Note.DrumPad.Orange, 112 },
     };
 
-        public static readonly Dictionary<int, Note.DrumPad> CYMBAL_TO_PAD_LOOKUP = PAD_TO_CYMBAL_LOOKUP.ToDictionary((i) => i.Value, (i) => i.Key);
+        public static readonly IReadOnlyDictionary<int, Note.DrumPad> CYMBAL_TO_PAD_LOOKUP = PAD_TO_CYMBAL_LOOKUP.ToDictionary((i) => i.Value, (i) => i.Key);
     }
 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -47,6 +47,8 @@ namespace MoonscraperChartEditor.Song.IO
         public const string SECTION_PREFIX_RB2 = "section ";
         public const string SECTION_PREFIX_RB3 = "prc_";
 
+        // This event is valid both with and without brackets.
+        // The bracketed version follows the style of other existing .mid text events.
         public const string CHART_DYNAMICS_TEXT = "ENABLE_CHART_DYNAMICS";
         public const string CHART_DYNAMICS_TEXT_BRACKET = "[ENABLE_CHART_DYNAMICS]";
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -59,36 +59,36 @@ namespace MoonscraperChartEditor.Song.IO
 
         // Lookup tables
         public static readonly IReadOnlyDictionary<Song.Difficulty, int> GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
-    {
-        { Song.Difficulty.Easy, 60 },
-        { Song.Difficulty.Medium, 72 },
-        { Song.Difficulty.Hard, 84 },
-        { Song.Difficulty.Expert, 96 }
-    };
+        {
+            { Song.Difficulty.Easy, 60 },
+            { Song.Difficulty.Medium, 72 },
+            { Song.Difficulty.Hard, 84 },
+            { Song.Difficulty.Expert, 96 }
+        };
 
         public static readonly IReadOnlyDictionary<Song.Difficulty, int> GHL_GUITAR_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
-    {
-        { Song.Difficulty.Easy, 58 },
-        { Song.Difficulty.Medium, 70 },
-        { Song.Difficulty.Hard, 82 },
-        { Song.Difficulty.Expert, 94 }
-    };
+        {
+            { Song.Difficulty.Easy, 58 },
+            { Song.Difficulty.Medium, 70 },
+            { Song.Difficulty.Hard, 82 },
+            { Song.Difficulty.Expert, 94 }
+        };
 
         public static readonly IReadOnlyDictionary<Song.Difficulty, int> DRUMS_DIFF_START_LOOKUP = new Dictionary<Song.Difficulty, int>()
-    {
-        { Song.Difficulty.Easy, 60 },
-        { Song.Difficulty.Medium, 72 },
-        { Song.Difficulty.Hard, 84 },
-        { Song.Difficulty.Expert, 96 }
-    };
+        {
+            { Song.Difficulty.Easy, 60 },
+            { Song.Difficulty.Medium, 72 },
+            { Song.Difficulty.Hard, 84 },
+            { Song.Difficulty.Expert, 96 }
+        };
 
         // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring
         public static readonly IReadOnlyDictionary<Note.DrumPad, int> PAD_TO_CYMBAL_LOOKUP = new Dictionary<Note.DrumPad, int>()
-    {
-        { Note.DrumPad.Yellow, 110 },
-        { Note.DrumPad.Blue, 111 },
-        { Note.DrumPad.Orange, 112 },
-    };
+        {
+            { Note.DrumPad.Yellow, 110 },
+            { Note.DrumPad.Blue, 111 },
+            { Note.DrumPad.Orange, 112 },
+        };
 
         public static readonly IReadOnlyDictionary<int, Note.DrumPad> CYMBAL_TO_PAD_LOOKUP = PAD_TO_CYMBAL_LOOKUP.ToDictionary((i) => i.Value, (i) => i.Key);
     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -765,11 +765,6 @@ namespace MoonscraperChartEditor.Song.IO
                         Note.Flags defaultFlags = Note.Flags.None;
                         DrumPadDefaultFlags.TryGetValue(pad, out defaultFlags);
 
-                        if (processFnDict.ContainsKey(key))
-                        {
-                            processFnDict.Remove(key);
-                        }
-
                         if (enableVelocity && pad != Note.DrumPad.Kick)
                         {
                             processFnDict.Add(key, (in EventProcessParams eventProcessParams) =>
@@ -814,11 +809,6 @@ namespace MoonscraperChartEditor.Song.IO
             {
                 int pad = (int)keyVal.Key;
                 int midiKey = keyVal.Value;
-
-                if (processFnDict.ContainsKey(midiKey))
-                {
-                    processFnDict.Remove(midiKey);
-                }
 
                 processFnDict.Add(midiKey, (in EventProcessParams eventProcessParams) =>
                 {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using NAudio.Midi;
 using MoonscraperEngine;
-using System.Collections.ObjectModel;
 
 namespace MoonscraperChartEditor.Song.IO
 {
@@ -51,8 +50,8 @@ namespace MoonscraperChartEditor.Song.IO
             public Song.Instrument instrument;
             public Chart currentUnrecognisedChart;
             public MidiEvent midiEvent;
-            public ReadOnlyDictionary<int, EventProcessFn> noteProcessMap;
-            public ReadOnlyDictionary<string, ProcessModificationProcessFn> textProcessMap;
+            public IReadOnlyDictionary<int, EventProcessFn> noteProcessMap;
+            public IReadOnlyDictionary<string, ProcessModificationProcessFn> textProcessMap;
             public List<EventProcessFn> delayedProcessesList;
         }
 
@@ -62,25 +61,25 @@ namespace MoonscraperChartEditor.Song.IO
         delegate void ProcessModificationProcessFn(ref EventProcessParams eventProcessParams);
 
         // These dictionaries map the NoteNumber of each midi note event to a specific function of how to process them
-        static readonly ReadOnlyDictionary<int, EventProcessFn> GuitarMidiNoteNumberToProcessFnMap = BuildGuitarMidiNoteNumberToProcessFnDict();
-        static readonly ReadOnlyDictionary<int, EventProcessFn> GhlGuitarMidiNoteNumberToProcessFnMap = BuildGhlGuitarMidiNoteNumberToProcessFnDict();
-        static readonly ReadOnlyDictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap = BuildDrumsMidiNoteNumberToProcessFnDict();
-        static readonly ReadOnlyDictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap_Velocity = BuildDrumsMidiNoteNumberToProcessFnDict(enableVelocity: true);
+        static readonly IReadOnlyDictionary<int, EventProcessFn> GuitarMidiNoteNumberToProcessFnMap = BuildGuitarMidiNoteNumberToProcessFnDict();
+        static readonly IReadOnlyDictionary<int, EventProcessFn> GhlGuitarMidiNoteNumberToProcessFnMap = BuildGhlGuitarMidiNoteNumberToProcessFnDict();
+        static readonly IReadOnlyDictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap = BuildDrumsMidiNoteNumberToProcessFnDict();
+        static readonly IReadOnlyDictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap_Velocity = BuildDrumsMidiNoteNumberToProcessFnDict(enableVelocity: true);
 
         // These dictionaries map the text of a MIDI text event to a specific function that processes them
-        static readonly ReadOnlyDictionary<string, ProcessModificationProcessFn> GuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, ProcessModificationProcessFn>(new Dictionary<string, ProcessModificationProcessFn>()
+        static readonly IReadOnlyDictionary<string, ProcessModificationProcessFn> GuitarTextEventToProcessFnMap = new Dictionary<string, ProcessModificationProcessFn>()
     {
-    });
+    };
 
-        static readonly ReadOnlyDictionary<string, ProcessModificationProcessFn> GhlGuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, ProcessModificationProcessFn>(new Dictionary<string, ProcessModificationProcessFn>()
+        static readonly IReadOnlyDictionary<string, ProcessModificationProcessFn> GhlGuitarTextEventToProcessFnMap = new Dictionary<string, ProcessModificationProcessFn>()
     {
-    });
+    };
 
-        static readonly ReadOnlyDictionary<string, ProcessModificationProcessFn> DrumsTextEventToProcessFnMap = new ReadOnlyDictionary<string, ProcessModificationProcessFn>(new Dictionary<string, ProcessModificationProcessFn>()
+        static readonly IReadOnlyDictionary<string, ProcessModificationProcessFn> DrumsTextEventToProcessFnMap = new Dictionary<string, ProcessModificationProcessFn>()
     {
         { MidIOHelper.CHART_DYNAMICS_TEXT, SwitchToDrumsVelocityProcessMap },
         { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, SwitchToDrumsVelocityProcessMap },
-    });
+    };
 
         public static Song ReadMidi(string path, ref CallbackState callBackState)
         {
@@ -555,7 +554,7 @@ namespace MoonscraperChartEditor.Song.IO
             }
         }
 
-        static ReadOnlyDictionary<int, EventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
+        static IReadOnlyDictionary<int, EventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
         {
             switch (gameMode)
             {
@@ -574,7 +573,7 @@ namespace MoonscraperChartEditor.Song.IO
             return GuitarMidiNoteNumberToProcessFnMap;
         }
 
-        static ReadOnlyDictionary<string, ProcessModificationProcessFn> GetTextEventProcessDict(Chart.GameMode gameMode)
+        static IReadOnlyDictionary<string, ProcessModificationProcessFn> GetTextEventProcessDict(Chart.GameMode gameMode)
         {
             switch (gameMode)
             {
@@ -600,7 +599,7 @@ namespace MoonscraperChartEditor.Song.IO
             processParams.noteProcessMap = DrumsMidiNoteNumberToProcessFnMap_Velocity;
         }
 
-        static ReadOnlyDictionary<int, EventProcessFn> BuildGuitarMidiNoteNumberToProcessFnDict()
+        static IReadOnlyDictionary<int, EventProcessFn> BuildGuitarMidiNoteNumberToProcessFnDict()
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
         {
@@ -655,10 +654,10 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            return new ReadOnlyDictionary<int, EventProcessFn>(processFnDict);
+            return processFnDict;
         }
 
-        static ReadOnlyDictionary<int, EventProcessFn> BuildGhlGuitarMidiNoteNumberToProcessFnDict()
+        static IReadOnlyDictionary<int, EventProcessFn> BuildGhlGuitarMidiNoteNumberToProcessFnDict()
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
         {
@@ -714,10 +713,10 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            return new ReadOnlyDictionary<int, EventProcessFn>(processFnDict);
+            return processFnDict;
         }
 
-        static ReadOnlyDictionary<int, EventProcessFn> BuildDrumsMidiNoteNumberToProcessFnDict(bool enableVelocity = false)
+        static IReadOnlyDictionary<int, EventProcessFn> BuildDrumsMidiNoteNumberToProcessFnDict(bool enableVelocity = false)
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
     {
@@ -827,7 +826,7 @@ namespace MoonscraperChartEditor.Song.IO
                 });
             }
 
-            return new ReadOnlyDictionary<int, EventProcessFn>(processFnDict);
+            return processFnDict;
         }
 
         static void ProcessNoteOnEventAsNote(in EventProcessParams eventProcessParams, Song.Difficulty diff, int ingameFret, Note.Flags defaultFlags = Note.Flags.None)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -19,7 +19,7 @@ namespace MoonscraperChartEditor.Song.IO
             WaitingForExternalInformation,
         }
 
-        static readonly Dictionary<string, Song.Instrument> c_trackNameToInstrumentMap = new Dictionary<string, Song.Instrument>()
+        static readonly IReadOnlyDictionary<string, Song.Instrument> c_trackNameToInstrumentMap = new Dictionary<string, Song.Instrument>()
     {
         { MidIOHelper.GUITAR_TRACK,        Song.Instrument.Guitar },
         { MidIOHelper.GUITAR_COOP_TRACK,   Song.Instrument.GuitarCoop },
@@ -31,13 +31,13 @@ namespace MoonscraperChartEditor.Song.IO
         { MidIOHelper.GHL_BASS_TRACK,      Song.Instrument.GHLiveBass },
     };
 
-        static readonly Dictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
+        static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
     {
         { "t1 gems",    true },
         { "beat",       true }
     };
 
-        static readonly Dictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()
+        static readonly IReadOnlyDictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()
     {
         // String list is ordered in priority. If it finds a file names with the first string it'll skip over the rest.
         // Otherwise just does a ToString on the AudioInstrument enum
@@ -609,7 +609,7 @@ namespace MoonscraperChartEditor.Song.IO
             }},
         };
 
-            Dictionary<Note.GuitarFret, int> FretToMidiKey = new Dictionary<Note.GuitarFret, int>()
+            IReadOnlyDictionary<Note.GuitarFret, int> FretToMidiKey = new Dictionary<Note.GuitarFret, int>()
         {
             // { Note.GuitarFret.Open, 0 }, // Handled by sysex event
             { Note.GuitarFret.Green, 0 },
@@ -667,7 +667,7 @@ namespace MoonscraperChartEditor.Song.IO
             }},
         };
 
-            Dictionary<Note.GHLiveGuitarFret, int> FretToMidiKey = new Dictionary<Note.GHLiveGuitarFret, int>()
+            IReadOnlyDictionary<Note.GHLiveGuitarFret, int> FretToMidiKey = new Dictionary<Note.GHLiveGuitarFret, int>()
         {
             { Note.GHLiveGuitarFret.Open, 0 },
             { Note.GHLiveGuitarFret.White1, 1 },
@@ -735,7 +735,7 @@ namespace MoonscraperChartEditor.Song.IO
         { MidIOHelper.STARPOWER_DRUM_FILL_4, ProcessNoteOnEventAsDrumFill },
     };
 
-            Dictionary<Note.DrumPad, int> DrumPadToMidiKey = new Dictionary<Note.DrumPad, int>()
+            IReadOnlyDictionary<Note.DrumPad, int> DrumPadToMidiKey = new Dictionary<Note.DrumPad, int>()
         {
             { Note.DrumPad.Kick, 0 },
             { Note.DrumPad.Red, 1 },
@@ -745,7 +745,7 @@ namespace MoonscraperChartEditor.Song.IO
             { Note.DrumPad.Green, 5 },
         };
 
-            Dictionary<Note.DrumPad, Note.Flags> DrumPadDefaultFlags = new Dictionary<Note.DrumPad, Note.Flags>()
+            IReadOnlyDictionary<Note.DrumPad, Note.Flags> DrumPadDefaultFlags = new Dictionary<Note.DrumPad, Note.Flags>()
         {
             { Note.DrumPad.Yellow, Note.Flags.ProDrums_Cymbal },
             { Note.DrumPad.Blue, Note.Flags.ProDrums_Cymbal },

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -51,6 +51,8 @@ namespace MoonscraperChartEditor.Song.IO
             public Song.Instrument instrument;
             public Chart currentUnrecognisedChart;
             public MidiEvent midiEvent;
+            public ReadOnlyDictionary<int, EventProcessFn> noteProcessMap;
+            public ReadOnlyDictionary<string, ProcessModificationProcessFn> textProcessMap;
             public List<EventProcessFn> delayedProcessesList;
         }
 
@@ -339,11 +341,10 @@ namespace MoonscraperChartEditor.Song.IO
                 song = song,
                 currentUnrecognisedChart = unrecognised,
                 instrument = instrument,
+                noteProcessMap = GetNoteProcessDict(gameMode),
+                textProcessMap = GetTextEventProcessDict(gameMode),
                 delayedProcessesList = new List<EventProcessFn>(),
             };
-
-            var noteProcessDict = GetNoteProcessDict(gameMode);
-            var textEventProcessDict = GetTextEventProcessDict(gameMode);
 
             if (instrument == Song.Instrument.Unrecognised)
             {
@@ -371,7 +372,7 @@ namespace MoonscraperChartEditor.Song.IO
                     else
                     {
                         ProcessModificationProcessFn processFn;
-                        if (textEventProcessDict.TryGetValue(eventName, out processFn))
+                        if (processParams.textProcessMap.TryGetValue(eventName, out processFn))
                         {
                             // This text event affects parsing of the .mid file, run its function and don't parse it into the chart
                             processParams.midiEvent = text;
@@ -405,7 +406,7 @@ namespace MoonscraperChartEditor.Song.IO
                     processParams.midiEvent = note;
 
                     EventProcessFn processFn;
-                    if (noteProcessDict.TryGetValue(note.NoteNumber, out processFn))
+                    if (processParams.noteProcessMap.TryGetValue(note.NoteNumber, out processFn))
                     {
                         processFn(processParams);
                     }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -771,7 +771,7 @@ namespace MoonscraperChartEditor.Song.IO
                             processFnDict.Remove(key);
                         }
 
-                        if (enableVelocity)
+                        if (enableVelocity && pad != Note.DrumPad.Kick)
                         {
                             processFnDict.Add(key, (in EventProcessParams eventProcessParams) =>
                             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -20,29 +20,29 @@ namespace MoonscraperChartEditor.Song.IO
         }
 
         static readonly IReadOnlyDictionary<string, Song.Instrument> c_trackNameToInstrumentMap = new Dictionary<string, Song.Instrument>()
-    {
-        { MidIOHelper.GUITAR_TRACK,        Song.Instrument.Guitar },
-        { MidIOHelper.GUITAR_COOP_TRACK,   Song.Instrument.GuitarCoop },
-        { MidIOHelper.BASS_TRACK,          Song.Instrument.Bass },
-        { MidIOHelper.RHYTHM_TRACK,        Song.Instrument.Rhythm },
-        { MidIOHelper.KEYS_TRACK,          Song.Instrument.Keys },
-        { MidIOHelper.DRUMS_TRACK,         Song.Instrument.Drums },
-        { MidIOHelper.GHL_GUITAR_TRACK,    Song.Instrument.GHLiveGuitar },
-        { MidIOHelper.GHL_BASS_TRACK,      Song.Instrument.GHLiveBass },
-    };
+        {
+            { MidIOHelper.GUITAR_TRACK,        Song.Instrument.Guitar },
+            { MidIOHelper.GUITAR_COOP_TRACK,   Song.Instrument.GuitarCoop },
+            { MidIOHelper.BASS_TRACK,          Song.Instrument.Bass },
+            { MidIOHelper.RHYTHM_TRACK,        Song.Instrument.Rhythm },
+            { MidIOHelper.KEYS_TRACK,          Song.Instrument.Keys },
+            { MidIOHelper.DRUMS_TRACK,         Song.Instrument.Drums },
+            { MidIOHelper.GHL_GUITAR_TRACK,    Song.Instrument.GHLiveGuitar },
+            { MidIOHelper.GHL_BASS_TRACK,      Song.Instrument.GHLiveBass },
+        };
 
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
-    {
-        { "t1 gems",    true },
-        { "beat",       true }
-    };
+        {
+            { "t1 gems",    true },
+            { "beat",       true }
+        };
 
         static readonly IReadOnlyDictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()
-    {
-        // String list is ordered in priority. If it finds a file names with the first string it'll skip over the rest.
-        // Otherwise just does a ToString on the AudioInstrument enum
-        { Song.AudioInstrument.Drum, new string[] { "drums", "drums_1" } },
-    };
+        {
+            // String list is ordered in priority. If it finds a file names with the first string it'll skip over the rest.
+            // Otherwise just does a ToString on the AudioInstrument enum
+            { Song.AudioInstrument.Drum, new string[] { "drums", "drums_1" } },
+        };
 
         struct EventProcessParams
         {
@@ -68,18 +68,18 @@ namespace MoonscraperChartEditor.Song.IO
 
         // These dictionaries map the text of a MIDI text event to a specific function that processes them
         static readonly IReadOnlyDictionary<string, ProcessModificationProcessFn> GuitarTextEventToProcessFnMap = new Dictionary<string, ProcessModificationProcessFn>()
-    {
-    };
+        {
+        };
 
         static readonly IReadOnlyDictionary<string, ProcessModificationProcessFn> GhlGuitarTextEventToProcessFnMap = new Dictionary<string, ProcessModificationProcessFn>()
-    {
-    };
+        {
+        };
 
         static readonly IReadOnlyDictionary<string, ProcessModificationProcessFn> DrumsTextEventToProcessFnMap = new Dictionary<string, ProcessModificationProcessFn>()
-    {
-        { MidIOHelper.CHART_DYNAMICS_TEXT, SwitchToDrumsVelocityProcessMap },
-        { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, SwitchToDrumsVelocityProcessMap },
-    };
+        {
+            { MidIOHelper.CHART_DYNAMICS_TEXT, SwitchToDrumsVelocityProcessMap },
+            { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, SwitchToDrumsVelocityProcessMap },
+        };
 
         public static Song ReadMidi(string path, ref CallbackState callBackState)
         {
@@ -602,22 +602,22 @@ namespace MoonscraperChartEditor.Song.IO
         static IReadOnlyDictionary<int, EventProcessFn> BuildGuitarMidiNoteNumberToProcessFnDict()
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
-        {
-            { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
-            { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
-                ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
-            }},
-        };
+            {
+                { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
+                { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
+                    ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
+                }},
+            };
 
             IReadOnlyDictionary<Note.GuitarFret, int> FretToMidiKey = new Dictionary<Note.GuitarFret, int>()
-        {
-            // { Note.GuitarFret.Open, 0 }, // Handled by sysex event
-            { Note.GuitarFret.Green, 0 },
-            { Note.GuitarFret.Red, 1 },
-            { Note.GuitarFret.Yellow, 2 },
-            { Note.GuitarFret.Blue, 3 },
-            { Note.GuitarFret.Orange, 4 },
-        };
+            {
+                // { Note.GuitarFret.Open, 0 }, // Handled by sysex event
+                { Note.GuitarFret.Green, 0 },
+                { Note.GuitarFret.Red, 1 },
+                { Note.GuitarFret.Yellow, 2 },
+                { Note.GuitarFret.Blue, 3 },
+                { Note.GuitarFret.Orange, 4 },
+            };
 
             foreach (var difficulty in EnumX<Song.Difficulty>.Values)
             {
@@ -660,23 +660,23 @@ namespace MoonscraperChartEditor.Song.IO
         static IReadOnlyDictionary<int, EventProcessFn> BuildGhlGuitarMidiNoteNumberToProcessFnDict()
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
-        {
-            { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
-            { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
-                ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
-            }},
-        };
+            {
+                { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
+                { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
+                    ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
+                }},
+            };
 
             IReadOnlyDictionary<Note.GHLiveGuitarFret, int> FretToMidiKey = new Dictionary<Note.GHLiveGuitarFret, int>()
-        {
-            { Note.GHLiveGuitarFret.Open, 0 },
-            { Note.GHLiveGuitarFret.White1, 1 },
-            { Note.GHLiveGuitarFret.White2, 2 },
-            { Note.GHLiveGuitarFret.White3, 3 },
-            { Note.GHLiveGuitarFret.Black1, 4 },
-            { Note.GHLiveGuitarFret.Black2, 5 },
-            { Note.GHLiveGuitarFret.Black3, 6 },
-        };
+            {
+                { Note.GHLiveGuitarFret.Open, 0 },
+                { Note.GHLiveGuitarFret.White1, 1 },
+                { Note.GHLiveGuitarFret.White2, 2 },
+                { Note.GHLiveGuitarFret.White3, 3 },
+                { Note.GHLiveGuitarFret.Black1, 4 },
+                { Note.GHLiveGuitarFret.Black2, 5 },
+                { Note.GHLiveGuitarFret.Black3, 6 },
+            };
 
             foreach (var difficulty in EnumX<Song.Difficulty>.Values)
             {
@@ -719,38 +719,38 @@ namespace MoonscraperChartEditor.Song.IO
         static IReadOnlyDictionary<int, EventProcessFn> BuildDrumsMidiNoteNumberToProcessFnDict(bool enableVelocity = false)
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
-    {
-        { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
-        { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
-            ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
-        }},
-        { MidIOHelper.DOUBLE_KICK_NOTE, (in EventProcessParams eventProcessParams) => {
-            ProcessNoteOnEventAsNote(eventProcessParams, Song.Difficulty.Expert, (int)Note.DrumPad.Kick, Note.Flags.InstrumentPlus);
-        }},
+            {
+                { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
+                { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
+                    ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT);
+                }},
+                { MidIOHelper.DOUBLE_KICK_NOTE, (in EventProcessParams eventProcessParams) => {
+                    ProcessNoteOnEventAsNote(eventProcessParams, Song.Difficulty.Expert, (int)Note.DrumPad.Kick, Note.Flags.InstrumentPlus);
+                }},
 
-        { MidIOHelper.STARPOWER_DRUM_FILL_0, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_1, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_2, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_3, ProcessNoteOnEventAsDrumFill },
-        { MidIOHelper.STARPOWER_DRUM_FILL_4, ProcessNoteOnEventAsDrumFill },
-    };
+                { MidIOHelper.STARPOWER_DRUM_FILL_0, ProcessNoteOnEventAsDrumFill },
+                { MidIOHelper.STARPOWER_DRUM_FILL_1, ProcessNoteOnEventAsDrumFill },
+                { MidIOHelper.STARPOWER_DRUM_FILL_2, ProcessNoteOnEventAsDrumFill },
+                { MidIOHelper.STARPOWER_DRUM_FILL_3, ProcessNoteOnEventAsDrumFill },
+                { MidIOHelper.STARPOWER_DRUM_FILL_4, ProcessNoteOnEventAsDrumFill },
+            };
 
             IReadOnlyDictionary<Note.DrumPad, int> DrumPadToMidiKey = new Dictionary<Note.DrumPad, int>()
-        {
-            { Note.DrumPad.Kick, 0 },
-            { Note.DrumPad.Red, 1 },
-            { Note.DrumPad.Yellow, 2 },
-            { Note.DrumPad.Blue, 3 },
-            { Note.DrumPad.Orange, 4 },
-            { Note.DrumPad.Green, 5 },
-        };
+            {
+                { Note.DrumPad.Kick, 0 },
+                { Note.DrumPad.Red, 1 },
+                { Note.DrumPad.Yellow, 2 },
+                { Note.DrumPad.Blue, 3 },
+                { Note.DrumPad.Orange, 4 },
+                { Note.DrumPad.Green, 5 },
+            };
 
             IReadOnlyDictionary<Note.DrumPad, Note.Flags> DrumPadDefaultFlags = new Dictionary<Note.DrumPad, Note.Flags>()
-        {
-            { Note.DrumPad.Yellow, Note.Flags.ProDrums_Cymbal },
-            { Note.DrumPad.Blue, Note.Flags.ProDrums_Cymbal },
-            { Note.DrumPad.Orange, Note.Flags.ProDrums_Cymbal },
-        };
+            {
+                { Note.DrumPad.Yellow, Note.Flags.ProDrums_Cymbal },
+                { Note.DrumPad.Blue, Note.Flags.ProDrums_Cymbal },
+                { Note.DrumPad.Orange, Note.Flags.ProDrums_Cymbal },
+            };
 
             foreach (var difficulty in EnumX<Song.Difficulty>.Values)
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -54,7 +54,10 @@ namespace MoonscraperChartEditor.Song.IO
             public List<EventProcessFn> delayedProcessesList;
         }
 
+        // Delegate for functions that parse something into the chart
         delegate void EventProcessFn(in EventProcessParams eventProcessParams);
+        // Delegate for functions that modify how the chart should be parsed
+        delegate void ProcessModificationProcessFn(ref EventProcessParams eventProcessParams);
 
         // These dictionaries map the NoteNumber of each midi note event to a specific function of how to process them
         static readonly ReadOnlyDictionary<int, EventProcessFn> GuitarMidiNoteNumberToProcessFnMap = BuildGuitarMidiNoteNumberToProcessFnDict();
@@ -62,20 +65,20 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly ReadOnlyDictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap = BuildDrumsMidiNoteNumberToProcessFnDict();
 
         // These dictionaries map the text of a MIDI text event to a specific function that processes them
-        static readonly ReadOnlyDictionary<string, EventProcessFn> GuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, EventProcessFn>(new Dictionary<string, EventProcessFn>()
+        static readonly ReadOnlyDictionary<string, ProcessModificationProcessFn> GuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, ProcessModificationProcessFn>(new Dictionary<string, ProcessModificationProcessFn>()
     {
     });
 
-        static readonly ReadOnlyDictionary<string, EventProcessFn> GhlGuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, EventProcessFn>(new Dictionary<string, EventProcessFn>()
+        static readonly ReadOnlyDictionary<string, ProcessModificationProcessFn> GhlGuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, ProcessModificationProcessFn>(new Dictionary<string, ProcessModificationProcessFn>()
     {
     });
 
-        static readonly ReadOnlyDictionary<string, EventProcessFn> DrumsTextEventToProcessFnMap = new ReadOnlyDictionary<string, EventProcessFn>(new Dictionary<string, EventProcessFn>()
+        static readonly ReadOnlyDictionary<string, ProcessModificationProcessFn> DrumsTextEventToProcessFnMap = new ReadOnlyDictionary<string, ProcessModificationProcessFn>(new Dictionary<string, ProcessModificationProcessFn>()
     {
-        { MidIOHelper.CHART_DYNAMICS_TEXT, (in EventProcessParams eventProcessParams) => {
+        { MidIOHelper.CHART_DYNAMICS_TEXT, (ref EventProcessParams eventProcessParams) => {
             BuildDrumsMidiNoteNumberToProcessFnDict(enableVelocity: true);
         }},
-        { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, (in EventProcessParams eventProcessParams) => {
+        { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, (ref EventProcessParams eventProcessParams) => {
             BuildDrumsMidiNoteNumberToProcessFnDict(enableVelocity: true);
         }}
     });
@@ -367,12 +370,12 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                     else
                     {
-                        EventProcessFn processFn;
+                        ProcessModificationProcessFn processFn;
                         if (textEventProcessDict.TryGetValue(eventName, out processFn))
                         {
                             // This text event affects parsing of the .mid file, run its function and don't parse it into the chart
                             processParams.midiEvent = text;
-                            processFn(processParams);
+                            processFn(ref processParams);
                         }
                         else
                         {
@@ -573,7 +576,7 @@ namespace MoonscraperChartEditor.Song.IO
             return GuitarMidiNoteNumberToProcessFnMap;
         }
 
-        static ReadOnlyDictionary<string, EventProcessFn> GetTextEventProcessDict(Chart.GameMode gameMode)
+        static ReadOnlyDictionary<string, ProcessModificationProcessFn> GetTextEventProcessDict(Chart.GameMode gameMode)
         {
             switch (gameMode)
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using NAudio.Midi;
 using MoonscraperEngine;
+using System.Collections.ObjectModel;
 
 namespace MoonscraperChartEditor.Song.IO
 {
@@ -56,20 +57,20 @@ namespace MoonscraperChartEditor.Song.IO
         delegate void EventProcessFn(in EventProcessParams eventProcessParams);
 
         // These dictionaries map the NoteNumber of each midi note event to a specific function of how to process them
-        static readonly Dictionary<int, EventProcessFn> GuitarMidiNoteNumberToProcessFnMap = BuildGuitarMidiNoteNumberToProcessFnDict();
-        static readonly Dictionary<int, EventProcessFn> GhlGuitarMidiNoteNumberToProcessFnMap = BuildGhlGuitarMidiNoteNumberToProcessFnDict();
-        static readonly Dictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap = BuildDrumsMidiNoteNumberToProcessFnDict();
+        static readonly ReadOnlyDictionary<int, EventProcessFn> GuitarMidiNoteNumberToProcessFnMap = BuildGuitarMidiNoteNumberToProcessFnDict();
+        static readonly ReadOnlyDictionary<int, EventProcessFn> GhlGuitarMidiNoteNumberToProcessFnMap = BuildGhlGuitarMidiNoteNumberToProcessFnDict();
+        static readonly ReadOnlyDictionary<int, EventProcessFn> DrumsMidiNoteNumberToProcessFnMap = BuildDrumsMidiNoteNumberToProcessFnDict();
 
         // These dictionaries map the text of a MIDI text event to a specific function that processes them
-        static readonly Dictionary<string, EventProcessFn> GuitarTextEventToProcessFnMap = new Dictionary<string, EventProcessFn>()
+        static readonly ReadOnlyDictionary<string, EventProcessFn> GuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, EventProcessFn>(new Dictionary<string, EventProcessFn>()
     {
-    };
+    });
 
-        static readonly Dictionary<string, EventProcessFn> GhlGuitarTextEventToProcessFnMap = new Dictionary<string, EventProcessFn>()
+        static readonly ReadOnlyDictionary<string, EventProcessFn> GhlGuitarTextEventToProcessFnMap = new ReadOnlyDictionary<string, EventProcessFn>(new Dictionary<string, EventProcessFn>()
     {
-    };
+    });
 
-        static readonly Dictionary<string, EventProcessFn> DrumsTextEventToProcessFnMap = new Dictionary<string, EventProcessFn>()
+        static readonly ReadOnlyDictionary<string, EventProcessFn> DrumsTextEventToProcessFnMap = new ReadOnlyDictionary<string, EventProcessFn>(new Dictionary<string, EventProcessFn>()
     {
         { MidIOHelper.CHART_DYNAMICS_TEXT, (in EventProcessParams eventProcessParams) => {
             BuildDrumsMidiNoteNumberToProcessFnDict(enableVelocity: true);
@@ -77,7 +78,7 @@ namespace MoonscraperChartEditor.Song.IO
         { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, (in EventProcessParams eventProcessParams) => {
             BuildDrumsMidiNoteNumberToProcessFnDict(enableVelocity: true);
         }}
-    };
+    });
 
         public static Song ReadMidi(string path, ref CallbackState callBackState)
         {
@@ -553,7 +554,7 @@ namespace MoonscraperChartEditor.Song.IO
             }
         }
 
-        static Dictionary<int, EventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
+        static ReadOnlyDictionary<int, EventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
         {
             switch (gameMode)
             {
@@ -572,7 +573,7 @@ namespace MoonscraperChartEditor.Song.IO
             return GuitarMidiNoteNumberToProcessFnMap;
         }
 
-        static Dictionary<string, EventProcessFn> GetTextEventProcessDict(Chart.GameMode gameMode)
+        static ReadOnlyDictionary<string, EventProcessFn> GetTextEventProcessDict(Chart.GameMode gameMode)
         {
             switch (gameMode)
             {
@@ -586,7 +587,7 @@ namespace MoonscraperChartEditor.Song.IO
             }
         }
 
-        static Dictionary<int, EventProcessFn> BuildGuitarMidiNoteNumberToProcessFnDict()
+        static ReadOnlyDictionary<int, EventProcessFn> BuildGuitarMidiNoteNumberToProcessFnDict()
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
         {
@@ -641,10 +642,10 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            return processFnDict;
+            return new ReadOnlyDictionary<int, EventProcessFn>(processFnDict);
         }
 
-        static Dictionary<int, EventProcessFn> BuildGhlGuitarMidiNoteNumberToProcessFnDict()
+        static ReadOnlyDictionary<int, EventProcessFn> BuildGhlGuitarMidiNoteNumberToProcessFnDict()
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
         {
@@ -700,10 +701,10 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             };
 
-            return processFnDict;
+            return new ReadOnlyDictionary<int, EventProcessFn>(processFnDict);
         }
 
-        static Dictionary<int, EventProcessFn> BuildDrumsMidiNoteNumberToProcessFnDict(bool enableVelocity = false)
+        static ReadOnlyDictionary<int, EventProcessFn> BuildDrumsMidiNoteNumberToProcessFnDict(bool enableVelocity = false)
         {
             var processFnDict = new Dictionary<int, EventProcessFn>()
     {
@@ -813,7 +814,7 @@ namespace MoonscraperChartEditor.Song.IO
                 });
             }
 
-            return processFnDict;
+            return new ReadOnlyDictionary<int, EventProcessFn>(processFnDict);
         }
 
         static void ProcessNoteOnEventAsNote(in EventProcessParams eventProcessParams, Song.Difficulty diff, int ingameFret, Note.Flags defaultFlags = Note.Flags.None)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -509,6 +509,7 @@ namespace MoonscraperChartEditor.Song.IO
             List<SortableBytes> eventList = new List<SortableBytes>();
 
             ChartEvent soloOnEvent = null;
+            bool dynamicsFound = false;
             foreach (ChartObject chartObject in chart.chartObjects)
             {
                 Note note = chartObject as Note;
@@ -526,10 +527,12 @@ namespace MoonscraperChartEditor.Song.IO
                     {
                         if (note.flags.HasFlag(Note.Flags.ProDrums_Accent))
                         {
+                            dynamicsFound = true;
                             velocity = MidIOHelper.VELOCITY_ACCENT;
                         }
                         else if (note.flags.HasFlag(Note.Flags.ProDrums_Ghost))
                         {
+                            dynamicsFound = true;
                             velocity = MidIOHelper.VELOCITY_GHOST;
                         }
                     }
@@ -692,6 +695,14 @@ namespace MoonscraperChartEditor.Song.IO
 
                     InsertionSort(eventList, offEvent);
                 }
+            }
+
+            if (dynamicsFound)
+            {
+                byte[] textEvent = MetaTextEvent(MetaTextEventType.Text, "[" + MidIOHelper.CHART_DYNAMICS_TEXT + "]");
+                SortableBytes dynamicsEvent = new SortableBytes(1, textEvent); // Place at the start of the track, just after the track name event
+
+                InsertionSort(eventList, dynamicsEvent);
             }
 
             return eventList.ToArray();

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -545,7 +545,7 @@ namespace MoonscraperChartEditor.Song.IO
                         Note.Flags noteFlags = note.flags & ~bannedFlags;   // Last ditched error correction
 
                         // Forced notes               
-                        if ((noteFlags & Note.Flags.Forced) != 0 && note.type != Note.NoteType.Tap && (note.previous == null || (note.previous.tick != note.tick)))     // Don't overlap on chords
+                        if (noteFlags.HasFlag(Note.Flags.Forced) && note.type != Note.NoteType.Tap && (note.previous == null || (note.previous.tick != note.tick)))     // Don't overlap on chords
                         {
                             // Add a note
                             int difficultyNumber;
@@ -568,7 +568,7 @@ namespace MoonscraperChartEditor.Song.IO
 
                         if (writeGlobalTrackEvents)
                         {
-                            if (instrument == Song.Instrument.Drums && ((noteFlags & Note.Flags.ProDrums_Cymbal) == 0))     // We want to write our flags if the cymbal is toggled OFF, as these notes are cymbals by default
+                            if (instrument == Song.Instrument.Drums && !noteFlags.HasFlag(Note.Flags.ProDrums_Cymbal))     // We want to write our flags if the cymbal is toggled OFF, as these notes are cymbals by default
                             {
                                 int tomToggleNoteNumber;
                                 if (MidIOHelper.PAD_TO_CYMBAL_LOOKUP.TryGetValue(note.drumPad, out tomToggleNoteNumber))
@@ -583,12 +583,12 @@ namespace MoonscraperChartEditor.Song.IO
 
                             int openNote = gameMode == Chart.GameMode.GHLGuitar ? (int)Note.GHLiveGuitarFret.Open : (int)Note.GuitarFret.Open;
                             // Add tap sysex events
-                            bool isStartOfTapRange = note.rawNote != openNote && (noteFlags & Note.Flags.Tap) != 0 && (note.previous == null || (note.previous.flags & Note.Flags.Tap) == 0);
+                            bool isStartOfTapRange = note.rawNote != openNote && noteFlags.HasFlag(Note.Flags.Tap) && (note.previous == null || (note.previous.flags & Note.Flags.Tap) == 0);
                             if (isStartOfTapRange)  // This note is a tap while the previous one isn't as we're creating a range
                             {
                                 // Find the next non-tap note
                                 Note nextNonTap = note;
-                                while (nextNonTap.next != null && nextNonTap.rawNote != openNote && (nextNonTap.next.flags & Note.Flags.Tap) != 0)
+                                while (nextNonTap.next != null && nextNonTap.rawNote != openNote && nextNonTap.next.flags.HasFlag(Note.Flags.Tap))
                                     nextNonTap = nextNonTap.next;
 
                                 // Tap event = 08-50-53-00-00-FF-04-01, end with 01 for On, 00 for Off

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -48,68 +48,68 @@ namespace MoonscraperChartEditor.Song.IO
         }
 
         static readonly IReadOnlyDictionary<Song.Instrument, string> c_instrumentToTrackNameDict = new Dictionary<Song.Instrument, string>()
-    {
-        { Song.Instrument.Guitar,           MidIOHelper.GUITAR_TRACK },
-        { Song.Instrument.GuitarCoop,       MidIOHelper.GUITAR_COOP_TRACK },
-        { Song.Instrument.Bass,             MidIOHelper.BASS_TRACK },
-        { Song.Instrument.Rhythm,           MidIOHelper.RHYTHM_TRACK },
-        { Song.Instrument.Keys,             MidIOHelper.KEYS_TRACK },
-        { Song.Instrument.Drums,            MidIOHelper.DRUMS_TRACK },
-        { Song.Instrument.GHLiveGuitar,     MidIOHelper.GHL_GUITAR_TRACK },
-        { Song.Instrument.GHLiveBass,       MidIOHelper.GHL_BASS_TRACK },
-    };
+        {
+            { Song.Instrument.Guitar,           MidIOHelper.GUITAR_TRACK },
+            { Song.Instrument.GuitarCoop,       MidIOHelper.GUITAR_COOP_TRACK },
+            { Song.Instrument.Bass,             MidIOHelper.BASS_TRACK },
+            { Song.Instrument.Rhythm,           MidIOHelper.RHYTHM_TRACK },
+            { Song.Instrument.Keys,             MidIOHelper.KEYS_TRACK },
+            { Song.Instrument.Drums,            MidIOHelper.DRUMS_TRACK },
+            { Song.Instrument.GHLiveGuitar,     MidIOHelper.GHL_GUITAR_TRACK },
+            { Song.Instrument.GHLiveBass,       MidIOHelper.GHL_BASS_TRACK },
+        };
 
         static readonly IReadOnlyDictionary<Song.Difficulty, int> c_difficultyToMidiNoteWriteDict = new Dictionary<Song.Difficulty, int>()
-    {
-        { Song.Difficulty.Easy,             60 },
-        { Song.Difficulty.Medium,           72 },
-        { Song.Difficulty.Hard,             84 },
-        { Song.Difficulty.Expert,           96 },
-    };
+        {
+            { Song.Difficulty.Easy,             60 },
+            { Song.Difficulty.Medium,           72 },
+            { Song.Difficulty.Hard,             84 },
+            { Song.Difficulty.Expert,           96 },
+        };
 
         static readonly IReadOnlyDictionary<int, int> c_guitarNoteMidiWriteOffsets = new Dictionary<int, int>()
-    {
-        { (int)Note.GuitarFret.Open,     0},     // Gets replaced by an sysex event
-        { (int)Note.GuitarFret.Green,    0},
-        { (int)Note.GuitarFret.Red,      1},
-        { (int)Note.GuitarFret.Yellow,   2},
-        { (int)Note.GuitarFret.Blue,     3},
-        { (int)Note.GuitarFret.Orange,   4},
-    };
+        {
+            { (int)Note.GuitarFret.Open,     0},     // Gets replaced by an sysex event
+            { (int)Note.GuitarFret.Green,    0},
+            { (int)Note.GuitarFret.Red,      1},
+            { (int)Note.GuitarFret.Yellow,   2},
+            { (int)Note.GuitarFret.Blue,     3},
+            { (int)Note.GuitarFret.Orange,   4},
+        };
 
         static readonly IReadOnlyDictionary<int, int> c_drumNoteMidiWriteOffsets = new Dictionary<int, int>()
-    {
-        { (int)Note.DrumPad.Kick,     0},
-        { (int)Note.DrumPad.Red,      1},
-        { (int)Note.DrumPad.Yellow,   2},
-        { (int)Note.DrumPad.Blue,     3},
-        { (int)Note.DrumPad.Orange,   4},
-        { (int)Note.DrumPad.Green,    5},
-    };
+        {
+            { (int)Note.DrumPad.Kick,     0},
+            { (int)Note.DrumPad.Red,      1},
+            { (int)Note.DrumPad.Yellow,   2},
+            { (int)Note.DrumPad.Blue,     3},
+            { (int)Note.DrumPad.Orange,   4},
+            { (int)Note.DrumPad.Green,    5},
+        };
 
         static readonly IReadOnlyDictionary<int, int> c_ghlNoteMidiWriteOffsets = new Dictionary<int, int>()
-    {
-        { (int)Note.GHLiveGuitarFret.Open,   -2},
-        { (int)Note.GHLiveGuitarFret.White1, -1},
-        { (int)Note.GHLiveGuitarFret.White2, 0},
-        { (int)Note.GHLiveGuitarFret.White3, 1},
-        { (int)Note.GHLiveGuitarFret.Black1, 2},
-        { (int)Note.GHLiveGuitarFret.Black2, 3},
-        { (int)Note.GHLiveGuitarFret.Black3, 4},
-    };
+        {
+            { (int)Note.GHLiveGuitarFret.Open,   -2},
+            { (int)Note.GHLiveGuitarFret.White1, -1},
+            { (int)Note.GHLiveGuitarFret.White2, 0},
+            { (int)Note.GHLiveGuitarFret.White3, 1},
+            { (int)Note.GHLiveGuitarFret.Black1, 2},
+            { (int)Note.GHLiveGuitarFret.Black2, 3},
+            { (int)Note.GHLiveGuitarFret.Black3, 4},
+        };
 
         static readonly IReadOnlyDictionary<Chart.GameMode, IReadOnlyDictionary<int, int>> c_gameModeNoteWriteOffsetDictLookup = new Dictionary<Chart.GameMode, IReadOnlyDictionary<int, int>>()
-    {
-        { Chart.GameMode.Guitar,    c_guitarNoteMidiWriteOffsets },
-        { Chart.GameMode.Drums,     c_drumNoteMidiWriteOffsets },
-        { Chart.GameMode.GHLGuitar, c_ghlNoteMidiWriteOffsets },
-    };
+        {
+            { Chart.GameMode.Guitar,    c_guitarNoteMidiWriteOffsets },
+            { Chart.GameMode.Drums,     c_drumNoteMidiWriteOffsets },
+            { Chart.GameMode.GHLGuitar, c_ghlNoteMidiWriteOffsets },
+        };
 
         static readonly IReadOnlyDictionary<Note.NoteType, int> c_forcingMidiWriteOffsets = new Dictionary<Note.NoteType, int>()
-    {
-        { Note.NoteType.Hopo, 5 },
-        { Note.NoteType.Strum, 6 },
-    };
+        {
+            { Note.NoteType.Hopo, 5 },
+            { Note.NoteType.Strum, 6 },
+        };
 
         delegate void ProcessVocalEventBytesFn(in VocalProcessingParams processParams);
         static readonly IReadOnlyDictionary<string, ProcessVocalEventBytesFn> vocalPrefixProcessList = new Dictionary<string, ProcessVocalEventBytesFn>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -47,7 +47,7 @@ namespace MoonscraperChartEditor.Song.IO
             public List<SortableBytes> out_sortableBytes;
         }
 
-        static readonly Dictionary<Song.Instrument, string> c_instrumentToTrackNameDict = new Dictionary<Song.Instrument, string>()
+        static readonly IReadOnlyDictionary<Song.Instrument, string> c_instrumentToTrackNameDict = new Dictionary<Song.Instrument, string>()
     {
         { Song.Instrument.Guitar,           MidIOHelper.GUITAR_TRACK },
         { Song.Instrument.GuitarCoop,       MidIOHelper.GUITAR_COOP_TRACK },
@@ -59,7 +59,7 @@ namespace MoonscraperChartEditor.Song.IO
         { Song.Instrument.GHLiveBass,       MidIOHelper.GHL_BASS_TRACK },
     };
 
-        static readonly Dictionary<Song.Difficulty, int> c_difficultyToMidiNoteWriteDict = new Dictionary<Song.Difficulty, int>()
+        static readonly IReadOnlyDictionary<Song.Difficulty, int> c_difficultyToMidiNoteWriteDict = new Dictionary<Song.Difficulty, int>()
     {
         { Song.Difficulty.Easy,             60 },
         { Song.Difficulty.Medium,           72 },
@@ -67,7 +67,7 @@ namespace MoonscraperChartEditor.Song.IO
         { Song.Difficulty.Expert,           96 },
     };
 
-        static readonly Dictionary<int, int> c_guitarNoteMidiWriteOffsets = new Dictionary<int, int>()
+        static readonly IReadOnlyDictionary<int, int> c_guitarNoteMidiWriteOffsets = new Dictionary<int, int>()
     {
         { (int)Note.GuitarFret.Open,     0},     // Gets replaced by an sysex event
         { (int)Note.GuitarFret.Green,    0},
@@ -77,7 +77,7 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.GuitarFret.Orange,   4},
     };
 
-        static readonly Dictionary<int, int> c_drumNoteMidiWriteOffsets = new Dictionary<int, int>()
+        static readonly IReadOnlyDictionary<int, int> c_drumNoteMidiWriteOffsets = new Dictionary<int, int>()
     {
         { (int)Note.DrumPad.Kick,     0},
         { (int)Note.DrumPad.Red,      1},
@@ -87,7 +87,7 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.DrumPad.Green,    5},
     };
 
-        static readonly Dictionary<int, int> c_ghlNoteMidiWriteOffsets = new Dictionary<int, int>()
+        static readonly IReadOnlyDictionary<int, int> c_ghlNoteMidiWriteOffsets = new Dictionary<int, int>()
     {
         { (int)Note.GHLiveGuitarFret.Open,   -2},
         { (int)Note.GHLiveGuitarFret.White1, -1},
@@ -98,21 +98,21 @@ namespace MoonscraperChartEditor.Song.IO
         { (int)Note.GHLiveGuitarFret.Black3, 4},
     };
 
-        static readonly Dictionary<Chart.GameMode, Dictionary<int, int>> c_gameModeNoteWriteOffsetDictLookup = new Dictionary<Chart.GameMode, Dictionary<int, int>>()
+        static readonly IReadOnlyDictionary<Chart.GameMode, IReadOnlyDictionary<int, int>> c_gameModeNoteWriteOffsetDictLookup = new Dictionary<Chart.GameMode, IReadOnlyDictionary<int, int>>()
     {
         { Chart.GameMode.Guitar,    c_guitarNoteMidiWriteOffsets },
         { Chart.GameMode.Drums,     c_drumNoteMidiWriteOffsets },
         { Chart.GameMode.GHLGuitar, c_ghlNoteMidiWriteOffsets },
     };
 
-        static readonly Dictionary<Note.NoteType, int> c_forcingMidiWriteOffsets = new Dictionary<Note.NoteType, int>()
+        static readonly IReadOnlyDictionary<Note.NoteType, int> c_forcingMidiWriteOffsets = new Dictionary<Note.NoteType, int>()
     {
         { Note.NoteType.Hopo, 5 },
         { Note.NoteType.Strum, 6 },
     };
 
         delegate void ProcessVocalEventBytesFn(in VocalProcessingParams processParams);
-        static readonly Dictionary<string, ProcessVocalEventBytesFn> vocalPrefixProcessList = new Dictionary<string, ProcessVocalEventBytesFn>()
+        static readonly IReadOnlyDictionary<string, ProcessVocalEventBytesFn> vocalPrefixProcessList = new Dictionary<string, ProcessVocalEventBytesFn>()
         {
             { MidIOHelper.LYRIC_EVENT_PREFIX, (in VocalProcessingParams processParams) => {
                 const string prefix = MidIOHelper.LYRIC_EVENT_PREFIX;
@@ -995,7 +995,7 @@ namespace MoonscraperChartEditor.Song.IO
 
         static int GetMidiNoteNumber(Note note, Chart.GameMode gameMode, Song.Difficulty difficulty)
         {
-            Dictionary<int, int> noteToMidiOffsetDict;
+            IReadOnlyDictionary<int, int> noteToMidiOffsetDict;
             int difficultyNumber;
             int offset;
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -699,7 +699,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             if (dynamicsFound)
             {
-                byte[] textEvent = MetaTextEvent(MetaTextEventType.Text, "[" + MidIOHelper.CHART_DYNAMICS_TEXT + "]");
+                byte[] textEvent = MetaTextEvent(MetaTextEventType.Text, MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET);
                 SortableBytes dynamicsEvent = new SortableBytes(1, textEvent); // Place at the start of the track, just after the track name event
 
                 InsertionSort(eventList, dynamicsEvent);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
@@ -52,6 +52,8 @@ public enum MSChartEditorInputActions
     NoteSetHopo,
     NoteSetTap,
     NoteSetCymbal,
+    NoteSetAccent,
+    NoteSetGhost,
     
     PlayPause,
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -78,6 +78,8 @@ public enum MSChartEditorInputActions
     ToggleNoteTap,
     ToggleNoteCymbal,
     ToggleNoteDoubleKick,
+    ToggleNoteAccent,
+    ToggleNoteGhost,
     ToggleStarpowerDrumsFillActivation,
     ToggleViewMode, 
     

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
@@ -13,8 +13,8 @@ using MoonscraperEngine.Input;
  * 2. Open Scenes/Config Editors/Input Editor
  * 3. Click on the Input Builder object and locate the Input Config Builder script
  * 4. Click the button "Load Config From File", which will load /Assets/Database/InputPropertiesConfig.json
- * 6. The field InputProperties/Shortcut Input will now be populated. Scroll down to find your new action and set up the new properties
- * 7. Click the button "Save Config To File" and overwrite InputPropertiesConfig.json
+ * 5. The field InputProperties/Shortcut Input will now be populated. Scroll down to find your new action and set up the new properties
+ * 6. Click the button "Save Config To File" and overwrite InputPropertiesConfig.json
  */
 
 public enum MSChartEditorInputActions

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Input/MSChartEditorInput.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -12,8 +12,7 @@ using MoonscraperEngine.Input;
  * 1. Add to the enum list
  * 2. Open Scenes/Config Editors/Input Editor
  * 3. Click on the Input Builder object and locate the Input Config Builder script
- * 4. Click the button "Load Config From File"
- * 5. Open the file /Assets/Database/InputPropertiesConfig.json
+ * 4. Click the button "Load Config From File", which will load /Assets/Database/InputPropertiesConfig.json
  * 6. The field InputProperties/Shortcut Input will now be populated. Scroll down to find your new action and set up the new properties
  * 7. Click the button "Save Config To File" and overwrite InputPropertiesConfig.json
  */

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/NoteVisuals/NoteVisualsManager.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/NoteVisuals/NoteVisualsManager.cs
@@ -99,10 +99,14 @@ public class NoteVisualsManager : MonoBehaviour {
         if (!text)
             return;
 
+        text.text = "";
+
         bool isDoubleKick = Globals.drumMode && note.IsOpenNote() && ((note.flags & Note.Flags.DoubleKick) != 0);
+        bool isAccent = Globals.drumMode && ((note.flags & Note.Flags.ProDrums_Accent) != 0);
+        bool isGhost = Globals.drumMode && ((note.flags & Note.Flags.ProDrums_Ghost) != 0);
         bool culledFromLanes = note.ShouldBeCulledFromLanes(ChartEditor.Instance.laneInfo);
 
-        bool active = isDoubleKick | culledFromLanes;
+        bool active = isDoubleKick | isAccent | isGhost | culledFromLanes;
 
         Vector3 position = Vector3.zero;
         position.z = -0.3f;  // Places the text above the note due to rotation
@@ -115,6 +119,22 @@ public class NoteVisualsManager : MonoBehaviour {
         else if (culledFromLanes)
         {
             text.text = "Lane Merged";
+        }
+
+        // Handle separately since these flags may be applied to a merged note
+        if (isAccent)
+        {
+            if (string.IsNullOrEmpty(text.text))
+                text.text = "Accent";
+            else
+                text.text += "\nAccent";
+        }
+        else if (isGhost)
+        {
+            if (string.IsNullOrEmpty(text.text))
+                text.text = "Ghost";
+            else
+                text.text += "\nGhost";
         }
 
         text.transform.localPosition = position;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using UnityEngine;
@@ -247,12 +247,14 @@ public class NotePropertiesPanelController : PropertiesPanelController {
 	
     public void setTap()
     {
-        OnNoteFlagToggleChanged(tapToggle, Note.Flags.Tap);
+        // A note can only be forced or a tap, not both
+        OnNoteFlagToggleChanged(tapToggle, Note.Flags.Tap, Note.Flags.Forced);
     }
 
     public void setForced()
     {
-        OnNoteFlagToggleChanged(forcedToggle, Note.Flags.Forced);
+        // A note can only be forced or a tap, not both
+        OnNoteFlagToggleChanged(forcedToggle, Note.Flags.Forced, Note.Flags.Tap);
     }
 
     public void setCymbal()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -247,37 +247,37 @@ public class NotePropertiesPanelController : PropertiesPanelController {
 	
     public void setTap()
     {
-        SetNoteFlag(tapToggle, Note.Flags.Tap);
+        OnNoteFlagToggleChanged(tapToggle, Note.Flags.Tap);
     }
 
     public void setForced()
     {
-        SetNoteFlag(forcedToggle, Note.Flags.Forced);
+        OnNoteFlagToggleChanged(forcedToggle, Note.Flags.Forced);
     }
 
     public void setCymbal()
     {
-        SetNoteFlag(cymbalToggle, Note.Flags.ProDrums_Cymbal);
+        OnNoteFlagToggleChanged(cymbalToggle, Note.Flags.ProDrums_Cymbal);
     }
 
     public void setDoubleKick()
     {
-        SetNoteFlag(doubleKickToggle, Note.Flags.DoubleKick);
+        OnNoteFlagToggleChanged(doubleKickToggle, Note.Flags.DoubleKick);
     }
 
     public void setAccent()
     {
         // A note can only be either an accent or a ghost, not both
-        SetNoteFlag(accentToggle, Note.Flags.ProDrums_Accent, Note.Flags.ProDrums_Ghost);
+        OnNoteFlagToggleChanged(accentToggle, Note.Flags.ProDrums_Accent, Note.Flags.ProDrums_Ghost);
     }
 
     public void setGhost()
     {
         // A note can only be either an accent or a ghost, not both
-        SetNoteFlag(ghostToggle, Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent);
+        OnNoteFlagToggleChanged(ghostToggle, Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent);
     }
 
-    void SetNoteFlag(Toggle toggle, Note.Flags flag, Note.Flags flagToExclude = Note.Flags.None)
+    void OnNoteFlagToggleChanged(Toggle toggle, Note.Flags flag, Note.Flags flagToExclude = Note.Flags.None)
     {
         if (toggleBlockingActive)
             return;
@@ -298,21 +298,23 @@ public class NotePropertiesPanelController : PropertiesPanelController {
                 return;
         }
 
-        SetNoteFlag(ref newFlags, flag, toggle.isOn);
+        newFlags = ToggleFlags(newFlags, flag, toggle.isOn);
         if ((newFlags & flagToExclude) != Note.Flags.None)
         {
-            SetNoteFlag(ref newFlags, flagToExclude, false);
+            newFlags = ToggleFlags(newFlags, flagToExclude, false);
         }
 
         SetNewFlags(currentNote, newFlags);
     }
 
-    void SetNoteFlag(ref Note.Flags flags, Note.Flags flagsToToggle, bool enable)
+    Note.Flags ToggleFlags(Note.Flags flags, Note.Flags flagsToToggle, bool enabled)
     {
-        if (enable)
+        if (enabled)
             flags |= flagsToToggle;
         else
             flags &= ~flagsToToggle;
+
+        return flags;
     }
 
     void SetNewFlags(Note note, Note.Flags newFlags)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using UnityEngine;
@@ -225,168 +225,59 @@ public class NotePropertiesPanelController : PropertiesPanelController {
 	
     public void setTap()
     {
+        SetNoteFlag(tapToggle, Note.Flags.Tap);
+    }
+
+    public void setForced()
+    {
+        SetNoteFlag(forcedToggle, Note.Flags.Forced);
+    }
+
+    public void setCymbal()
+    {
+        SetNoteFlag(cymbalToggle, Note.Flags.ProDrums_Cymbal);
+    }
+
+    public void setDoubleKick()
+    {
+        SetNoteFlag(doubleKickToggle, Note.Flags.DoubleKick);
+    }
+
+    public void SetNoteFlag(Toggle toggle, Note.Flags flag)
+    {
         if (toggleBlockingActive)
             return;
 
         if (IsInNoteTool())
         {
-            SetTapNoteTool();
+            if (toggle.interactable)
+                SetNoteToolFlag(ref noteToolController.desiredFlags, flag);
         }
         else
         {
-            SetTapNote();
-        }
-    }
-
-    void SetTapNoteTool()
-    {
-        if (tapToggle.interactable)
-            SetNoteToolFlag(ref noteToolController.desiredFlags, tapToggle, Note.Flags.Tap);
-    }
-
-    void SetTapNote()
-    {
-        if (currentNote == prevNote)
-        {
-            var newFlags = currentNote.flags;
-
-            if (currentNote != null)
+            if (currentNote == prevNote)
             {
-                if (tapToggle.isOn)
-                    newFlags |= Note.Flags.Tap;
-                else
-                    newFlags &= ~Note.Flags.Tap;
-            }
+                var newFlags = currentNote.flags;
 
-            SetNewFlags(currentNote, newFlags);
+                if (currentNote != null)
+                {
+                    if (toggle.isOn)
+                        newFlags |= flag;
+                    else
+                        newFlags &= ~flag;
+                }
+
+                SetNewFlags(currentNote, newFlags);
+            }
         }
     }
 
-    void SetNoteToolFlag(ref Note.Flags flags, Toggle uiToggle, Note.Flags flagsToToggle)
+    void SetNoteToolFlag(ref Note.Flags flags, Note.Flags flagsToToggle)
     {
         if ((flags & flagsToToggle) == 0)
             flags |= flagsToToggle;
         else
             flags &= ~flagsToToggle;
-    }
-
-    public void setForced()
-    {
-        if (toggleBlockingActive)
-            return;
-
-        if (IsInNoteTool())
-        {
-            SetForcedNoteTool();
-        }
-        else
-        {
-            SetForcedNote();
-        }
-    }
-
-    public void setCymbal()
-    {
-        if (toggleBlockingActive)
-            return;
-
-        if (IsInNoteTool())
-        {
-            SetCymbalNoteTool();
-        }
-        else
-        {
-            SetCymbalNote();
-        }
-    }
-
-    public void setDoubleKick()
-    {
-        if (toggleBlockingActive)
-            return;
-
-        if (IsInNoteTool())
-        {
-            SetDoubleKickNoteTool();
-        }
-        else
-        {
-            SetDoubleKickNote();
-        }
-    }
-
-    void SetForcedNote()
-    {
-        if (currentNote == prevNote)
-        {
-            var newFlags = currentNote.flags;
-
-            if (currentNote != null)
-            {
-                if (forcedToggle.isOn)
-                    newFlags |= Note.Flags.Forced;
-                else
-                    newFlags &= ~Note.Flags.Forced;
-            }
-
-            SetNewFlags(currentNote, newFlags);
-        }
-    }
-
-    void SetForcedNoteTool()
-    {
-        if (forcedToggle.interactable)
-            SetNoteToolFlag(ref noteToolController.desiredFlags, forcedToggle, Note.Flags.Forced);
-    }
-
-    void SetCymbalNote()
-    {
-        if (currentNote == prevNote)
-        {
-            var newFlags = currentNote.flags;
-
-            if (currentNote != null)
-            {
-                if (cymbalToggle.isOn)
-                    newFlags |= Note.Flags.ProDrums_Cymbal;
-                else
-                    newFlags &= ~Note.Flags.ProDrums_Cymbal;
-            }
-
-            SetNewFlags(currentNote, newFlags);
-        }
-
-    }
-
-    void SetCymbalNoteTool()
-    {
-        if (cymbalToggle.interactable)
-            SetNoteToolFlag(ref noteToolController.desiredFlags, cymbalToggle, Note.Flags.ProDrums_Cymbal);
-    }
-
-    void SetDoubleKickNote()
-    {
-        if (currentNote == prevNote)
-        {
-            var newFlags = currentNote.flags;
-
-            if (currentNote != null)
-            {
-                if (doubleKickToggle.isOn)
-                    newFlags |= Note.Flags.DoubleKick;
-                else
-                    newFlags &= ~Note.Flags.DoubleKick;
-            }
-
-            SetNewFlags(currentNote, newFlags);
-        }
-
-    }
-
-    void SetDoubleKickNoteTool()
-    {
-        if (doubleKickToggle.interactable)
-            SetNoteToolFlag(ref noteToolController.desiredFlags, doubleKickToggle, Note.Flags.DoubleKick);
     }
 
     void SetNewFlags(Note note, Note.Flags newFlags)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -194,8 +194,8 @@ public class NotePropertiesPanelController : PropertiesPanelController {
             {
                 cymbalToggle.interactable = NoteFunctions.AllowedToBeCymbal(currentNote);
                 doubleKickToggle.interactable = NoteFunctions.AllowedToBeDoubleKick(currentNote, editor.currentDifficulty);
-                accentToggle.interactable = NoteFunctions.AllowedToBeAccentOrGhost(currentNote);
-                ghostToggle.interactable = NoteFunctions.AllowedToBeAccentOrGhost(currentNote);
+                accentToggle.interactable = NoteFunctions.AllowedToBeAccent(currentNote);
+                ghostToggle.interactable = NoteFunctions.AllowedToBeGhost(currentNote);
             }
             else
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using UnityEngine;
@@ -16,6 +16,8 @@ public class NotePropertiesPanelController : PropertiesPanelController {
     public Toggle forcedToggle;
     public Toggle cymbalToggle;
     public Toggle doubleKickToggle;
+    public Toggle accentToggle;
+    public Toggle ghostToggle;
 
     public GameObject noteToolObject;
     PlaceNoteController noteToolController;
@@ -142,6 +144,8 @@ public class NotePropertiesPanelController : PropertiesPanelController {
         tapToggle.isOn = (flags & Note.Flags.Tap) != 0;
         cymbalToggle.isOn = (flags & Note.Flags.ProDrums_Cymbal) != 0;
         doubleKickToggle.isOn = (flags & Note.Flags.DoubleKick) != 0;
+        accentToggle.isOn = (flags & Note.Flags.ProDrums_Accent) != 0;
+        ghostToggle.isOn = (flags & Note.Flags.ProDrums_Ghost) != 0;
 
         toggleBlockingActive = false;
     }
@@ -156,6 +160,8 @@ public class NotePropertiesPanelController : PropertiesPanelController {
         tapToggle.gameObject.SetActive(!drumsMode);
         cymbalToggle.gameObject.SetActive(proDrumsMode);
         doubleKickToggle.gameObject.SetActive(proDrumsMode);
+        accentToggle.gameObject.SetActive(proDrumsMode);
+        ghostToggle.gameObject.SetActive(proDrumsMode);
 
         if (!drumsMode)
         {
@@ -181,16 +187,22 @@ public class NotePropertiesPanelController : PropertiesPanelController {
             {
                 cymbalToggle.interactable = noteToolController.cymbalInteractable;
                 doubleKickToggle.interactable = noteToolController.doubleKickInteractable;
+                accentToggle.interactable = noteToolController.accentInteractable;
+                ghostToggle.interactable = noteToolController.ghostInteractable;
             }
             else if (!IsInNoteTool())
             {
                 cymbalToggle.interactable = NoteFunctions.AllowedToBeCymbal(currentNote);
                 doubleKickToggle.interactable = NoteFunctions.AllowedToBeDoubleKick(currentNote, editor.currentDifficulty);
+                accentToggle.interactable = NoteFunctions.AllowedToBeAccentOrGhost(currentNote);
+                ghostToggle.interactable = NoteFunctions.AllowedToBeAccentOrGhost(currentNote);
             }
             else
             {
                 cymbalToggle.interactable = true;
                 doubleKickToggle.interactable = true;
+                accentToggle.interactable = true;
+                ghostToggle.interactable = true;
             }
         }
     }
@@ -215,6 +227,16 @@ public class NotePropertiesPanelController : PropertiesPanelController {
         if (MSChartEditorInput.GetInputDown(MSChartEditorInputActions.ToggleNoteDoubleKick) && doubleKickToggle.interactable)
         {
             doubleKickToggle.isOn = !doubleKickToggle.isOn;
+        }
+
+        if (MSChartEditorInput.GetInputDown(MSChartEditorInputActions.ToggleNoteAccent) && accentToggle.interactable)
+        {
+            accentToggle.isOn = !accentToggle.isOn;
+        }
+
+        if (MSChartEditorInput.GetInputDown(MSChartEditorInputActions.ToggleNoteGhost) && ghostToggle.interactable)
+        {
+            ghostToggle.isOn = !ghostToggle.isOn;
         }
     }
 
@@ -241,6 +263,28 @@ public class NotePropertiesPanelController : PropertiesPanelController {
     public void setDoubleKick()
     {
         SetNoteFlag(doubleKickToggle, Note.Flags.DoubleKick);
+    }
+
+    public void setAccent()
+    {
+        SetNoteFlag(accentToggle, Note.Flags.ProDrums_Accent);
+        // TODO: This doesn't seem to work correctly
+        // A note can only be either an accent or a ghost, not both
+        // if (accentToggle.isOn && ghostToggle.isOn)
+        // {
+        //     ghostToggle.isOn = false;
+        // }
+    }
+
+    public void setGhost()
+    {
+        SetNoteFlag(ghostToggle, Note.Flags.ProDrums_Ghost);
+        // TODO: This doesn't seem to work correctly
+        // A note can only be either an accent or a ghost, not both
+        // if (ghostToggle.isOn && accentToggle.isOn)
+        // {
+        //     accentToggle.isOn = false;
+        // }
     }
 
     public void SetNoteFlag(Toggle toggle, Note.Flags flag)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -267,58 +267,49 @@ public class NotePropertiesPanelController : PropertiesPanelController {
 
     public void setAccent()
     {
-        SetNoteFlag(accentToggle, Note.Flags.ProDrums_Accent);
-        // TODO: This doesn't seem to work correctly
         // A note can only be either an accent or a ghost, not both
-        // if (accentToggle.isOn && ghostToggle.isOn)
-        // {
-        //     ghostToggle.isOn = false;
-        // }
+        SetNoteFlag(accentToggle, Note.Flags.ProDrums_Accent, Note.Flags.ProDrums_Ghost);
     }
 
     public void setGhost()
     {
-        SetNoteFlag(ghostToggle, Note.Flags.ProDrums_Ghost);
-        // TODO: This doesn't seem to work correctly
         // A note can only be either an accent or a ghost, not both
-        // if (ghostToggle.isOn && accentToggle.isOn)
-        // {
-        //     accentToggle.isOn = false;
-        // }
+        SetNoteFlag(ghostToggle, Note.Flags.ProDrums_Ghost, Note.Flags.ProDrums_Accent);
     }
 
-    void SetNoteFlag(Toggle toggle, Note.Flags flag)
+    void SetNoteFlag(Toggle toggle, Note.Flags flag, Note.Flags flagToExclude = Note.Flags.None)
     {
         if (toggleBlockingActive)
             return;
 
+        Note.Flags newFlags;
         if (IsInNoteTool())
         {
             if (toggle.interactable)
-                SetNoteToolFlag(ref noteToolController.desiredFlags, flag);
+                newFlags = noteToolController.desiredFlags;
+            else
+                return;
         }
         else
         {
-            if (currentNote == prevNote)
-            {
-                var newFlags = currentNote.flags;
-
-                if (currentNote != null)
-                {
-                    if (toggle.isOn)
-                        newFlags |= flag;
-                    else
-                        newFlags &= ~flag;
-                }
-
-                SetNewFlags(currentNote, newFlags);
-            }
+            if (currentNote == prevNote && currentNote != null)
+                newFlags = currentNote.flags;
+            else
+                return;
         }
+
+        SetNoteFlag(ref newFlags, flag, toggle.isOn);
+        if ((newFlags & flagToExclude) != Note.Flags.None)
+        {
+            SetNoteFlag(ref newFlags, flagToExclude, false);
+        }
+
+        SetNewFlags(currentNote, newFlags);
     }
 
-    void SetNoteToolFlag(ref Note.Flags flags, Note.Flags flagsToToggle)
+    void SetNoteFlag(ref Note.Flags flags, Note.Flags flagsToToggle, bool enable)
     {
-        if ((flags & flagsToToggle) == 0)
+        if (enable)
             flags |= flagsToToggle;
         else
             flags &= ~flagsToToggle;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using UnityEngine;
@@ -287,7 +287,7 @@ public class NotePropertiesPanelController : PropertiesPanelController {
         // }
     }
 
-    public void SetNoteFlag(Toggle toggle, Note.Flags flag)
+    void SetNoteFlag(Toggle toggle, Note.Flags flag)
     {
         if (toggleBlockingActive)
             return;


### PR DESCRIPTION
This is not the end goal for accent/ghost support by a long shot, a number of things are left to be done.

Features:
- Load and save accents/ghosts from both .mid and .chart
- Edit drums notes to apply accents/ghosts
- Accents and ghosts are mutually exclusive, enabling one will disable the other
  - This could also be applied to guitar forced/tap flags as well, since notes can only be one note type at once
- Display "Accent" or "Ghost" above the note to indicate if it's an accent or ghost
- Input mappings for both toggling and applying accents/ghosts

Things that need to be done:
- Proper materials/models for accents/ghosts
- Accent and ghost notes will auto-play in gameplay mode, this shouldn't happen.