### PR TITLE
Fix issues #80-82

### DIFF
--- a/Moonscraper Chart Editor/Assets/Database/DefaultControls.json
+++ b/Moonscraper Chart Editor/Assets/Database/DefaultControls.json
@@ -567,6 +567,44 @@
             }
         },
         {
+            "action": "NoteSetAccent",
+            "input": {
+                "kbMaps": [
+                    {
+                        "modifiers": 0,
+                        "keys": [
+                            118
+                        ]
+                    },
+                    {
+                        "modifiers": 0,
+                        "keys": []
+                    }
+                ],
+                "gpButtonMaps": [],
+                "jsMaps": []
+            }
+        },
+        {
+            "action": "NoteSetGhost",
+            "input": {
+                "kbMaps": [
+                    {
+                        "modifiers": 0,
+                        "keys": [
+                            122
+                        ]
+                    },
+                    {
+                        "modifiers": 0,
+                        "keys": []
+                    }
+                ],
+                "gpButtonMaps": [],
+                "jsMaps": []
+            }
+        },
+        {
             "action": "PlayPause",
             "input": {
                 "kbMaps": [
@@ -1016,6 +1054,44 @@
                         "modifiers": 0,
                         "keys": [
                             120
+                        ]
+                    },
+                    {
+                        "modifiers": 0,
+                        "keys": []
+                    }
+                ],
+                "gpButtonMaps": [],
+                "jsMaps": []
+            }
+        },
+        {
+            "action": "ToggleNoteAccent",
+            "input": {
+                "kbMaps": [
+                    {
+                        "modifiers": 0,
+                        "keys": [
+                            118
+                        ]
+                    },
+                    {
+                        "modifiers": 0,
+                        "keys": []
+                    }
+                ],
+                "gpButtonMaps": [],
+                "jsMaps": []
+            }
+        },
+        {
+            "action": "ToggleNoteGhost",
+            "input": {
+                "kbMaps": [
+                    {
+                        "modifiers": 0,
+                        "keys": [
+                            122
                         ]
                     },
                     {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Services/Services.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Services/Services.cs
@@ -87,19 +87,15 @@ public class Services : MonoBehaviour
         }
     }
 
-    static bool _IsTyping
+    bool _IsTyping
     {
         get
         {
-            if (
-                EventSystem.current.currentSelectedGameObject == null ||
-                (EventSystem.current.currentSelectedGameObject.GetComponent<InputField>() == null &&
-                EventSystem.current.currentSelectedGameObject.GetComponent<TMPro.TMP_InputField>() == null &&
-                EventSystem.current.currentSelectedGameObject.GetComponent<MS_TMPro_InputField>() == null)
-                )
-                return false;
-            else
-                return true;
+            return (EventSystem.current.currentSelectedGameObject != null &&
+                (EventSystem.current.currentSelectedGameObject.GetComponent<InputField>() != null ||
+                EventSystem.current.currentSelectedGameObject.GetComponent<TMPro.TMP_InputField>() != null ||
+                EventSystem.current.currentSelectedGameObject.GetComponent<MS_TMPro_InputField>() != null)) ||
+                IsBindingsMenuActive;
         }
     }
 
@@ -271,6 +267,14 @@ public class Services : MonoBehaviour
         get
         {
             return uiServices.lyricEditor.isActiveAndEnabled;
+        }
+    }
+
+    public bool IsBindingsMenuActive
+    {
+        get
+        {
+            return uiServices.bindingsMenu.isActiveAndEnabled;
         }
     }
 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/NotePropertiesPanelController.cs
@@ -321,11 +321,13 @@ public class NotePropertiesPanelController : PropertiesPanelController {
 
     void SetNewFlags(Note note, Note.Flags newFlags)
     {
-        if (note.flags == newFlags)
-            return;
-
         if (editor.toolManager.currentToolId == EditorObjectToolManager.ToolID.Cursor)
         {
+            if (note.flags == newFlags)
+            {
+                return;
+            }
+
             Note newNote = new Note(note.tick, note.rawNote, note.length, newFlags);
             SongEditModifyValidated command = new SongEditModifyValidated(note, newNote);
             editor.commandStack.Push(command);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Menu Component Lookups/UIServices.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Menu Component Lookups/UIServices.cs
@@ -41,6 +41,20 @@ public class UIServices : MonoBehaviour {
         }
     }
 
+    ActionBindingsMenu m_bindingsMenu = null;
+    public ActionBindingsMenu bindingsMenu
+    {
+        get
+        {
+            if (!m_bindingsMenu)
+            {
+                m_bindingsMenu = GetComponentInChildren<ActionBindingsMenu>(true);
+            }
+
+            return m_bindingsMenu;
+        }
+    }
+
     bool _popupBlockerEnabled = false;
     Camera _uiCamera;
     public Camera uiCamera


### PR DESCRIPTION
Summary:

- Only check the current note's flags in the note properties panel if the current tool is the cursor tool (fixes #80)
- Accents are now mapped to V, and ghosts are mapped to Z (closes #81)
- Check if the key bindings menu is active as part of Services._IsTyping (fixes #82)