### PR TITLE
.mid: Add support for note-based tap marker and `ENHANCED_OPENS` text event, fix some asserts being hit, write all 5 drum roll notes

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -54,10 +54,12 @@ namespace MoonscraperChartEditor.Song.IO
         public const string SECTION_PREFIX_RB2 = "section ";
         public const string SECTION_PREFIX_RB3 = "prc_";
 
-        // This event is valid both with and without brackets.
-        // The bracketed version follows the style of other existing .mid text events.
+        // These events are valid both with and without brackets.
+        // The bracketed versions follow the style of other existing .mid text events.
         public const string CHART_DYNAMICS_TEXT = "ENABLE_CHART_DYNAMICS";
         public const string CHART_DYNAMICS_TEXT_BRACKET = "[ENABLE_CHART_DYNAMICS]";
+        public const string ENHANCED_OPENS_TEXT = "ENHANCED_OPENS";
+        public const string ENHANCED_OPENS_TEXT_BRACKET = "[ENHANCED_OPENS]";
 
         // Note velocities
         public const byte VELOCITY = 100;             // default note velocity for exporting

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -26,6 +26,7 @@ namespace MoonscraperChartEditor.Song.IO
         // Note numbers
         public const byte DOUBLE_KICK_NOTE = 95;
         public const byte SOLO_NOTE = 103;                 // http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
+        public const byte TAP_NOTE = 104;                  // https://strikeline.myjetbrains.com/youtrack/issue/CH-390
         public const byte LYRICS_PHRASE_1 = 105;           // http://docs.c3universe.com/rbndocs/index.php?title=Vocal_Authoring
         public const byte LYRICS_PHRASE_2 = 106;           // Rock Band charts before RB3 mark phrases using this note as well
         public const byte FLAM_MARKER = 109;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -26,7 +26,7 @@ namespace MoonscraperChartEditor.Song.IO
         // Note numbers
         public const byte DOUBLE_KICK_NOTE = 95;
         public const byte SOLO_NOTE = 103;                 // http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
-        public const byte TAP_NOTE = 104;                  // https://github.com/TheNathannator/GuitarGame_ChartFormats/blob/main/doc/FileFormats/.mid/Standard/5-Fret Guitar.md
+        public const byte TAP_NOTE_CH = 104;               // https://github.com/TheNathannator/GuitarGame_ChartFormats/blob/main/doc/FileFormats/.mid/Standard/5-Fret Guitar.md
         public const byte LYRICS_PHRASE_1 = 105;           // http://docs.c3universe.com/rbndocs/index.php?title=Vocal_Authoring
         public const byte LYRICS_PHRASE_2 = 106;           // Rock Band charts before RB3 mark phrases using this note as well
         public const byte FLAM_MARKER = 109;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -26,7 +26,7 @@ namespace MoonscraperChartEditor.Song.IO
         // Note numbers
         public const byte DOUBLE_KICK_NOTE = 95;
         public const byte SOLO_NOTE = 103;                 // http://docs.c3universe.com/rbndocs/index.php?title=Guitar_and_Bass_Authoring#Solo_Sections
-        public const byte TAP_NOTE = 104;                  // https://strikeline.myjetbrains.com/youtrack/issue/CH-390
+        public const byte TAP_NOTE = 104;                  // https://github.com/TheNathannator/GuitarGame_ChartFormats/blob/main/doc/FileFormats/.mid/Standard/5-Fret Guitar.md
         public const byte LYRICS_PHRASE_1 = 105;           // http://docs.c3universe.com/rbndocs/index.php?title=Vocal_Authoring
         public const byte LYRICS_PHRASE_2 = 106;           // Rock Band charts before RB3 mark phrases using this note as well
         public const byte FLAM_MARKER = 109;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -971,7 +971,7 @@ namespace MoonscraperChartEditor.Song.IO
 
                 lastChordTick = note.tick;
 
-                Debug.Assert(note.type == noteType);
+                Debug.Assert(note.type == noteType, $"Failed to set forced type! Expected: {noteType}  Actual: {note.type}\non {difficulty} {instrument} at tick {note.tick} ({TimeSpan.FromSeconds(note.time):mm':'ss'.'ff})");
             }
         }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1018,7 +1018,8 @@ namespace MoonscraperChartEditor.Song.IO
                             }
                             else
                             {
-                                // Open notes cannot become taps, they become HOPOs instead
+                                // Open notes cannot become taps
+                                // CH handles this by turning them into open HOPOs, we'll do the same here for consistency with them
                                 expectedForceFailure = true;
                                 // In the case that consecutive open notes are marked as taps, only the first will become a HOPO
                                 if (!note.cannotBeForced && !note.isNaturalHopo)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -930,11 +930,13 @@ namespace MoonscraperChartEditor.Song.IO
 
             for (int i = index; i < index + length; ++i)
             {
+                // Tap marking overrides all other forcing
                 if ((chart.notes[i].flags & Note.Flags.Tap) != 0)
                     continue;
 
                 Note note = chart.notes[i];
 
+                // Check if the chord has changed
                 if (lastChordTick != note.tick)
                 {
                     shouldBeForced = false;

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1030,6 +1030,7 @@ namespace MoonscraperChartEditor.Song.IO
                         }
 
                         default:
+                            Debug.Assert(false, $"Unhandled note type {noteType} in .mid forced type processing");
                             continue; // Unhandled
                     }
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -622,7 +622,7 @@ namespace MoonscraperChartEditor.Song.IO
             var processFnDict = new Dictionary<int, EventProcessFn>()
             {
                 { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
-                { MidIOHelper.TAP_NOTE, (in EventProcessParams eventProcessParams) => {
+                { MidIOHelper.TAP_NOTE_CH, (in EventProcessParams eventProcessParams) => {
                     ProcessNoteOnEventAsForcedType(eventProcessParams, Note.NoteType.Tap);
                 }},
                 { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
@@ -685,7 +685,7 @@ namespace MoonscraperChartEditor.Song.IO
             var processFnDict = new Dictionary<int, EventProcessFn>()
             {
                 { MidIOHelper.STARPOWER_NOTE, ProcessNoteOnEventAsStarpower },
-                { MidIOHelper.TAP_NOTE, (in EventProcessParams eventProcessParams) => {
+                { MidIOHelper.TAP_NOTE_CH, (in EventProcessParams eventProcessParams) => {
                     ProcessNoteOnEventAsForcedType(eventProcessParams, Note.NoteType.Tap);
                 }},
                 { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2020 Alexander Ong
+// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -964,48 +964,55 @@ namespace MoonscraperChartEditor.Song.IO
                     expectedForceFailure = false;
                     shouldBeForced = false;
 
-                    if (noteType == Note.NoteType.Strum)
+                    switch (noteType)
                     {
-                        if (!note.isChord && note.isNaturalHopo)
+                        case (Note.NoteType.Strum):
                         {
-                            shouldBeForced = true;
-                        }
-                    }
-                    else if (noteType == Note.NoteType.Hopo)
-                    {
-                        // Forcing consecutive same-fret HOPOs is possible in charts, but we do not allow it
-                        // (see RB2's chart of Steely Dan - Bodhisattva)
-                        if (!note.isNaturalHopo && note.cannotBeForced)
-                        {
-                            expectedForceFailure = true;
-                        }
-
-                        if (!note.cannotBeForced && (note.isChord || !note.isNaturalHopo))
-                        {
-                            shouldBeForced = true;
-                        }
-                    }
-                    else if (noteType == Note.NoteType.Tap)
-                    {
-                        if (!note.IsOpenNote())
-                        {
-                            note.flags |= Note.Flags.Tap;
-                            // Forced flag will be removed shortly after here
-                        }
-                        else
-                        {
-                            // Open notes cannot become taps, they become HOPOs instead
-                            expectedForceFailure = true;
-                            // In the case that consecutive open notes are marked as taps, only the first will become a HOPO
-                            if (!note.cannotBeForced && !note.isNaturalHopo)
+                            if (!note.isChord && note.isNaturalHopo)
                             {
                                 shouldBeForced = true;
                             }
+                            break;
                         }
-                    }
-                    else
-                    {
-                        continue;   // Unhandled
+
+                        case (Note.NoteType.Hopo):
+                        {
+                            // Forcing consecutive same-fret HOPOs is possible in charts, but we do not allow it
+                            // (see RB2's chart of Steely Dan - Bodhisattva)
+                            if (!note.isNaturalHopo && note.cannotBeForced)
+                            {
+                                expectedForceFailure = true;
+                            }
+
+                            if (!note.cannotBeForced && (note.isChord || !note.isNaturalHopo))
+                            {
+                                shouldBeForced = true;
+                            }
+                            break;
+                        }
+
+                        case (Note.NoteType.Tap):
+                        {
+                            if (!note.IsOpenNote())
+                            {
+                                note.flags |= Note.Flags.Tap;
+                                // Forced flag will be removed shortly after here
+                            }
+                            else
+                            {
+                                // Open notes cannot become taps, they become HOPOs instead
+                                expectedForceFailure = true;
+                                // In the case that consecutive open notes are marked as taps, only the first will become a HOPO
+                                if (!note.cannotBeForced && !note.isNaturalHopo)
+                                {
+                                    shouldBeForced = true;
+                                }
+                            }
+                            break;
+                        }
+
+                        default:
+                            continue; // Unhandled
                     }
 
                     if (shouldBeForced)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -1014,33 +1014,35 @@ namespace MoonscraperChartEditor.Song.IO
 
         static (SortableBytes, SortableBytes)[] GetStarpowerBytes(Starpower sp)
         {
+            uint startTick = sp.tick;
+            uint endTick = sp.tick + sp.length;
             bool isDrumFill = sp.flags.HasFlag(Starpower.Flags.ProDrums_Activation);
             // Drum fills are 5 notes instead of one
             // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
             if (isDrumFill)
             {
                 return new (SortableBytes, SortableBytes)[] {
-                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY })),
+                    (new SortableBytes(startTick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY }),
+                    new SortableBytes(endTick, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY })),
 
-                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY })),
+                    (new SortableBytes(startTick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY }),
+                    new SortableBytes(endTick, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY })),
 
-                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY })),
+                    (new SortableBytes(startTick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY }),
+                    new SortableBytes(endTick, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY })),
 
-                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY })),
+                    (new SortableBytes(startTick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY }),
+                    new SortableBytes(endTick, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY })),
 
-                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY }))
+                    (new SortableBytes(startTick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY }),
+                    new SortableBytes(endTick, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY }))
                 };
             }
             else
             {
                 return new (SortableBytes, SortableBytes)[] {
-                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY }))
+                    (new SortableBytes(startTick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY }),
+                    new SortableBytes(endTick, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY }))
                 };
             }
         }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -652,20 +652,22 @@ namespace MoonscraperChartEditor.Song.IO
                     {
                         // Starpower notes marked as a drum roll are written as 5 notes instead of 1
                         // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
-                        SortableBytes[] onEvents;
-                        SortableBytes[] offEvents;
-                        GetStarpowerBytes(sp, out onEvents, out offEvents);
-                        if (onEvents != null && offEvents != null && onEvents.Length == offEvents.Length)
+                        var events = GetStarpowerBytes(sp);
+                        if (events != null)
                         {
-                            // An assumption is made here that the MIDI notes are paired by index
-                            for (int i = 0; i < onEvents.Length && i < offEvents.Length; ++i)
+                            for (int i = 0; i < events.Length; ++i)
                             {
-                                InsertionSort(eventList, onEvents[i]);
+                                (var spOnEvent, var spOffEvent) = events[i];
+                                Debug.Assert(spOnEvent != null && spOffEvent != null, "Invalid starpower event pair in MIDI export!");
+                                if (spOnEvent == null || spOffEvent == null)
+                                    continue;
 
-                                if (offEvents[i].tick == onEvents[i].tick)
-                                    ++offEvents[i].tick;
+                                InsertionSort(eventList, spOnEvent);
 
-                                InsertionSort(eventList, offEvents[i]);
+                                if (spOffEvent.tick == spOnEvent.tick)
+                                    ++spOffEvent.tick;
+
+                                InsertionSort(eventList, spOffEvent);
                             }
                         }
                     }
@@ -750,20 +752,22 @@ namespace MoonscraperChartEditor.Song.IO
                 Starpower sp = chartObject as Starpower;
                 if (sp != null)     // Starpower cannot be split up between charts in a midi file
                 {
-                    SortableBytes[] onEvents;
-                    SortableBytes[] offEvents;
-                    GetStarpowerBytes(sp, out onEvents, out offEvents);
-                    if (onEvents != null && offEvents != null && onEvents.Length == offEvents.Length)
+                    var events = GetStarpowerBytes(sp);
+                    if (events != null)
                     {
-                        // An assumption is made here that the MIDI notes are paired by index
-                        for (int i = 0; i < onEvents.Length && i < offEvents.Length; ++i)
+                        for (int i = 0; i < events.Length; ++i)
                         {
-                            InsertionSort(eventList, onEvents[i]);
+                            (var spOnEvent, var spOffEvent) = events[i];
+                            Debug.Assert(spOnEvent != null && spOffEvent != null, "Invalid starpower event pair in MIDI export!");
+                            if (spOnEvent == null || spOffEvent == null)
+                                continue;
 
-                            if (offEvents[i].tick == onEvents[i].tick)
-                                ++offEvents[i].tick;
+                            InsertionSort(eventList, spOnEvent);
 
-                            InsertionSort(eventList, offEvents[i]);
+                            if (spOffEvent.tick == spOnEvent.tick)
+                                ++spOffEvent.tick;
+
+                            InsertionSort(eventList, spOffEvent);
                         }
                     }
                 }
@@ -1008,42 +1012,37 @@ namespace MoonscraperChartEditor.Song.IO
         /* CHART EVENT BYTE DETERMINING 
         ***********************************************************************************************/
 
-        static void GetStarpowerBytes(Starpower sp, out SortableBytes[] onEvents, out SortableBytes[] offEvents)
+        static (SortableBytes, SortableBytes)[] GetStarpowerBytes(Starpower sp)
         {
             bool isDrumFill = sp.flags.HasFlag(Starpower.Flags.ProDrums_Activation);
             // Drum fills are 5 notes instead of one
             // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
             if (isDrumFill)
             {
-                // Ensure that these remain in the same order in both arrays
-                onEvents = new SortableBytes[] {
-                    new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY }),
-                    new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY }),
-                    new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY }),
-                    new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY }),
-                    new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY })
-                };
+                return new (SortableBytes, SortableBytes)[] {
+                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY }),
+                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY })),
 
-                offEvents = new SortableBytes[] {
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_0, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY }),
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY })
+                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY }),
+                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_1, VELOCITY })),
+
+                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY }),
+                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_2, VELOCITY })),
+
+                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY }),
+                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_3, VELOCITY })),
+
+                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY }),
+                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_DRUM_FILL_4, VELOCITY }))
                 };
             }
             else
             {
-                onEvents = new SortableBytes[] {
-                    new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY })
-                };
-
-                offEvents = new SortableBytes[] {
-                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY })
+                return new (SortableBytes, SortableBytes)[] {
+                    (new SortableBytes(sp.tick, new byte[] { ON_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY }),
+                    new SortableBytes(sp.tick + sp.length, new byte[] { OFF_EVENT, MidIOHelper.STARPOWER_NOTE, VELOCITY }))
                 };
             }
-
-            Debug.Assert(onEvents.Length == offEvents.Length);
         }
 
         static void GetDrumRollBytes(DrumRoll roll, out SortableBytes onEvent, out SortableBytes offEvent)

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -658,7 +658,7 @@ namespace MoonscraperChartEditor.Song.IO
                         if (onEvents != null && offEvents != null && onEvents.Length == offEvents.Length)
                         {
                             // An assumption is made here that the MIDI notes are paired by index
-                            for (int i = 0; i < onEvents.Length && i < offEvents.Length; i++)
+                            for (int i = 0; i < onEvents.Length && i < offEvents.Length; ++i)
                             {
                                 InsertionSort(eventList, onEvents[i]);
 
@@ -756,7 +756,7 @@ namespace MoonscraperChartEditor.Song.IO
                     if (onEvents != null && offEvents != null && onEvents.Length == offEvents.Length)
                     {
                         // An assumption is made here that the MIDI notes are paired by index
-                        for (int i = 0; i < onEvents.Length && i < offEvents.Length; i++)
+                        for (int i = 0; i < onEvents.Length && i < offEvents.Length; ++i)
                         {
                             InsertionSort(eventList, onEvents[i]);
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -651,6 +651,7 @@ namespace MoonscraperChartEditor.Song.IO
                     if (sp != null)     // Starpower cannot be split up between charts in a midi file
                     {
                         // Starpower notes marked as a drum roll are written as 5 notes instead of 1
+                        // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
                         SortableBytes[] onEvents;
                         SortableBytes[] offEvents;
                         GetStarpowerBytes(sp, out onEvents, out offEvents);
@@ -1011,6 +1012,7 @@ namespace MoonscraperChartEditor.Song.IO
         {
             bool isDrumFill = sp.flags.HasFlag(Starpower.Flags.ProDrums_Activation);
             // Drum fills are 5 notes instead of one
+            // http://docs.c3universe.com/rbndocs/index.php?title=Drum_Authoring#Drum_Fills
             if (isDrumFill)
             {
                 // Ensure that these remain in the same order in both arrays


### PR DESCRIPTION
Summary:
- MidReader.ProcessNoteOnEventAsForcedTypePostDelay
  - Add message to assert
  - Add a couple comments for clarification
  - Add handling for setting note type to taps
  - Fix assert getting hit in cases where it's impossible for the note type to change:
    - Same-fret consecutive HOPOs, which are disallowed in MS but possible in chart files
    - Tap marking on open notes (they get turned into HOPOs instead where possible)
  - Use switch case on the type to be set instead of if-else chain
- Add process dictionary for `ENHANCED_OPENS` mode and switch to it when encountering that text event
- Write all 5 drum roll notes (120-124) instead of just the first (120)

Some more changes/fixes will be coming, wanted to split the PRs into smaller chunks where possible.