### PR TITLE
.mid: Add messages system, parse T1 GEMS and PART DRUMS_REAL_PS, add legacy SP fixup, rewrite SysEx parsing/writing, exclude VENUE track

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -10,13 +10,17 @@ namespace MoonscraperChartEditor.Song.IO
     public static class MidIOHelper
     {
         // Track names
+        public const string BEAT_TRACK = "BEAT";
         public const string EVENTS_TRACK = "EVENTS";
+        public const string VENUE_TRACK = "VENUE";
         public const string GUITAR_TRACK = "PART GUITAR";
+        public const string GH1_GUITAR_TRACK = "T1 GEMS";
         public const string GUITAR_COOP_TRACK = "PART GUITAR COOP";
         public const string BASS_TRACK = "PART BASS";
         public const string RHYTHM_TRACK = "PART RHYTHM";
         public const string KEYS_TRACK = "PART KEYS";
         public const string DRUMS_TRACK = "PART DRUMS";
+        public const string DRUMS_REAL_TRACK = "PART REAL_DRUMS_PS";
         public const string GHL_GUITAR_TRACK = "PART GUITAR GHL";
         public const string GHL_BASS_TRACK = "PART BASS GHL";
         public const string GHL_RHYTHM_TRACK = "PART RHYTHM GHL";

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections;
@@ -104,5 +104,75 @@ namespace MoonscraperChartEditor.Song.IO
         };
 
         public static readonly IReadOnlyDictionary<int, Note.DrumPad> CYMBAL_TO_PAD_LOOKUP = PAD_TO_CYMBAL_LOOKUP.ToDictionary((i) => i.Value, (i) => i.Key);
+
+        // SysEx event format
+        // https://dwsk.proboards.com/thread/404/song-standard-advancements
+
+        // Data as given by NAudio:
+        // sysexData[0]: SysEx event length
+        // sysexData[1-3]: Header
+        // sysexData[4]: Event type
+        // sysexData[5]: Difficulty
+        // sysexData[6]: Event code
+        // sysexData[7]: Event value
+
+        // This length and the following indicies may need to be adjusted if the MIDI parsing library ever changes.
+        // They both account for the length value that NAudio provides as the first value.
+        public const int SYSEX_LENGTH = 8;
+
+        public const int SYSEX_INDEX_HEADER_1 = 1;
+        public const int SYSEX_INDEX_HEADER_2 = 2;
+        public const int SYSEX_INDEX_HEADER_3 = 3;
+        public const int SYSEX_INDEX_TYPE = 4;
+        public const int SYSEX_INDEX_DIFFICULTY = 5;
+        public const int SYSEX_INDEX_CODE = 6;
+        public const int SYSEX_INDEX_VALUE = 7;
+
+        public const char SYSEX_HEADER_1 = 'P'; // 0x50
+        public const char SYSEX_HEADER_2 = 'S'; // 0x53
+        public const char SYSEX_HEADER_3 = '\0'; // 0x00
+
+        public const byte SYSEX_TYPE_PHRASE = 0x00;
+
+        public const byte SYSEX_DIFFICULTY_EASY = 0x00;
+        public const byte SYSEX_DIFFICULTY_MEDIUM = 0x01;
+        public const byte SYSEX_DIFFICULTY_HARD = 0x02;
+        public const byte SYSEX_DIFFICULTY_EXPERT = 0x03;
+        public const byte SYSEX_DIFFICULTY_ALL = 0xFF;
+
+        public static readonly Dictionary<byte, Song.Difficulty> SYSEX_TO_MS_DIFF_LOOKUP = new Dictionary<byte, Song.Difficulty>()
+        {
+            { SYSEX_DIFFICULTY_EASY, Song.Difficulty.Easy },
+            { SYSEX_DIFFICULTY_MEDIUM, Song.Difficulty.Medium },
+            { SYSEX_DIFFICULTY_HARD, Song.Difficulty.Hard },
+            { SYSEX_DIFFICULTY_EXPERT, Song.Difficulty.Expert }
+        };
+
+        public static readonly Dictionary<Song.Difficulty, byte> MS_TO_SYSEX_DIFF_LOOKUP = SYSEX_TO_MS_DIFF_LOOKUP.ToDictionary((i) => i.Value, (i) => i.Key);
+
+        public const byte SYSEX_CODE_GUITAR_OPEN = 0x01;
+        public const byte SYSEX_CODE_GUITAR_TAP = 0x04;
+
+        // These codes aren't used by us, they're here for informational/future purposes
+        public const byte SYSEX_CODE_REAL_DRUMS_HIHAT_OPEN = 0x05;
+        public const byte SYSEX_CODE_REAL_DRUMS_HIHAT_PEDAL = 0x06;
+        public const byte SYSEX_CODE_REAL_DRUMS_SNARE_RIMSHOT = 0x07;
+        public const byte SYSEX_CODE_REAL_DRUMS_HIHAT_SIZZLE = 0x08;
+        public const byte SYSEX_CODE_REAL_DRUMS_CYMBAL_AND_TOM_YELLOW = 0x11;
+        public const byte SYSEX_CODE_REAL_DRUMS_CYMBAL_AND_TOM_BLUE = 0x12;
+        public const byte SYSEX_CODE_REAL_DRUMS_CYMBAL_AND_TOM_GREEN = 0x13;
+        public const byte SYSEX_CODE_PRO_GUITAR_SLIDE_UP = 0x02;
+        public const byte SYSEX_CODE_PRO_GUITAR_SLIDE_DOWN = 0x03;
+        public const byte SYSEX_CODE_PRO_GUITAR_PALM_MUTE = 0x09;
+        public const byte SYSEX_CODE_PRO_GUITAR_VIBRATO = 0x0A;
+        public const byte SYSEX_CODE_PRO_GUITAR_HARMONIC = 0x0B;
+        public const byte SYSEX_CODE_PRO_GUITAR_PINCH_HARMONIC = 0x0C;
+        public const byte SYSEX_CODE_PRO_GUITAR_BEND = 0x0D;
+        public const byte SYSEX_CODE_PRO_GUITAR_ACCENT = 0x0E;
+        public const byte SYSEX_CODE_PRO_GUITAR_POP = 0x0F;
+        public const byte SYSEX_CODE_PRO_GUITAR_SLAP = 0x10;
+
+        public const byte SYSEX_VALUE_PHRASE_START = 0x01;
+        public const byte SYSEX_VALUE_PHRASE_END = 0x00;
     }
 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -254,17 +254,17 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             }
 
-            // Display warnings to user, and execute action if they select Yes (or in editor and params say to execute)
+            // Display messages to user, and execute action if they select Yes (or in editor and params say to execute)
             foreach (var processParams in messageList)
             {
 #if UNITY_EDITOR // The editor freezes when its message box API is used during parsing
                 if (!processParams.executeInEditor)
                 {
-                    Debug.Log("Auto-skipping action for warning: " + processParams.message);
+                    Debug.Log("Auto-skipping action for message: " + processParams.message);
                 }
                 else
                 {
-                    Debug.Log("Auto-executing action for warning: " + processParams.message);
+                    Debug.Log("Auto-executing action for message: " + processParams.message);
 #else
                 callBackState = CallbackState.WaitingForExternalInformation;
                 NativeMessageBox.Result result = NativeMessageBox.Show(processParams.message, processParams.title, NativeMessageBox.Type.YesNo, null);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -22,11 +22,13 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly IReadOnlyDictionary<string, Song.Instrument> c_trackNameToInstrumentMap = new Dictionary<string, Song.Instrument>()
         {
             { MidIOHelper.GUITAR_TRACK,        Song.Instrument.Guitar },
+            { MidIOHelper.GH1_GUITAR_TRACK,    Song.Instrument.Guitar },
             { MidIOHelper.GUITAR_COOP_TRACK,   Song.Instrument.GuitarCoop },
             { MidIOHelper.BASS_TRACK,          Song.Instrument.Bass },
             { MidIOHelper.RHYTHM_TRACK,        Song.Instrument.Rhythm },
             { MidIOHelper.KEYS_TRACK,          Song.Instrument.Keys },
             { MidIOHelper.DRUMS_TRACK,         Song.Instrument.Drums },
+            { MidIOHelper.DRUMS_REAL_TRACK,    Song.Instrument.Drums },
             { MidIOHelper.GHL_GUITAR_TRACK,    Song.Instrument.GHLiveGuitar },
             { MidIOHelper.GHL_BASS_TRACK,      Song.Instrument.GHLiveBass },
             { MidIOHelper.GHL_RHYTHM_TRACK,    Song.Instrument.GHLiveRhythm },
@@ -35,7 +37,6 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
         {
-            { MidIOHelper.GH1_GUITAR_TRACK, true },
             { MidIOHelper.BEAT_TRACK,       true },
         };
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -64,6 +64,7 @@ namespace MoonscraperChartEditor.Song.IO
             public MidiEvent midiEvent;
             public IReadOnlyDictionary<int, EventProcessFn> noteProcessMap;
             public IReadOnlyDictionary<string, ProcessModificationProcessFn> textProcessMap;
+            public IReadOnlyDictionary<byte, EventProcessFn> sysexProcessMap;
             public List<EventProcessFn> delayedProcessesList;
         }
 
@@ -94,6 +95,26 @@ namespace MoonscraperChartEditor.Song.IO
         {
             { MidIOHelper.CHART_DYNAMICS_TEXT, SwitchToDrumsVelocityProcessMap },
             { MidIOHelper.CHART_DYNAMICS_TEXT_BRACKET, SwitchToDrumsVelocityProcessMap },
+        };
+
+        static readonly Dictionary<byte, EventProcessFn> GuitarSysExEventToProcessFnMap = new Dictionary<byte, EventProcessFn>()
+        {
+            { MidIOHelper.SYSEX_CODE_GUITAR_OPEN, ProcessSysExEventPairAsOpenNoteModifier },
+            { MidIOHelper.SYSEX_CODE_GUITAR_TAP, (in EventProcessParams eventProcessParams) => {
+                ProcessSysExEventPairAsForcedType(eventProcessParams, Note.NoteType.Tap);
+            }},
+        };
+
+        static readonly Dictionary<byte, EventProcessFn> GhlGuitarSysExEventToProcessFnMap = new Dictionary<byte, EventProcessFn>()
+        {
+            { MidIOHelper.SYSEX_CODE_GUITAR_OPEN, ProcessSysExEventPairAsOpenNoteModifier },
+            { MidIOHelper.SYSEX_CODE_GUITAR_TAP, (in EventProcessParams eventProcessParams) => {
+                ProcessSysExEventPairAsForcedType(eventProcessParams, Note.NoteType.Tap);
+            }},
+        };
+
+        static readonly Dictionary<byte, EventProcessFn> DrumsSysExEventToProcessFnMap = new Dictionary<byte, EventProcessFn>()
+        {
         };
 
         // For handling things that require user intervention
@@ -411,7 +432,7 @@ namespace MoonscraperChartEditor.Song.IO
                 return;
             }
 
-            List<SysexEvent> tapAndOpenEvents = new List<SysexEvent>();
+            var sysexEventQueue = new List<PhaseShiftSysExStart>();
 
             Chart unrecognised = new Chart(song, Song.Instrument.Unrecognised);
             Chart.GameMode gameMode = Song.InstumentToChartGameMode(instrument);
@@ -423,6 +444,7 @@ namespace MoonscraperChartEditor.Song.IO
                 instrument = instrument,
                 noteProcessMap = GetNoteProcessDict(gameMode),
                 textProcessMap = GetTextEventProcessDict(gameMode),
+                sysexProcessMap = GetSysExEventProcessDict(gameMode),
                 delayedProcessesList = new List<EventProcessFn>(),
             };
 
@@ -495,7 +517,49 @@ namespace MoonscraperChartEditor.Song.IO
                 var sysexEvent = track[i] as SysexEvent;
                 if (sysexEvent != null)
                 {
-                    tapAndOpenEvents.Add(sysexEvent);
+                    PhaseShiftSysEx psEvent;
+                    if (!PhaseShiftSysEx.TryParse(sysexEvent, out psEvent))
+                    {
+                        // SysEx event is not a Phase Shift SysEx event
+                        Debug.LogWarning($"Encountered unknown SysEx event: {BitConverter.ToString(sysexEvent.GetData())}");
+                        continue;
+                    }
+
+                    if (psEvent.Type != MidIOHelper.SYSEX_TYPE_PHRASE)
+                    {
+                        Debug.LogWarning($"Encountered unknown Phase Shift SysEx event type {psEvent.Type}");
+                        continue;
+                    }
+
+                    if (psEvent.Value == MidIOHelper.SYSEX_VALUE_PHRASE_START)
+                    {
+                        sysexEventQueue.Add(new PhaseShiftSysExStart(psEvent));
+                    }
+                    else if (psEvent.Value == MidIOHelper.SYSEX_VALUE_PHRASE_END)
+                    {
+                        // Iterate through event queue in reverse to find the corresponding start event
+                        bool foundMatch = false;
+                        for (int startIndex = sysexEventQueue.Count - 1; startIndex >= 0; startIndex--)
+                        {
+                            var startEvent = sysexEventQueue[startIndex];
+                            if (startEvent.AbsoluteTime <= psEvent.AbsoluteTime && startEvent.MatchesWith(psEvent))
+                            {
+                                sysexEventQueue.RemoveAt(startIndex);
+                                startEvent.EndEvent = psEvent;
+                                foundMatch = true;
+
+                                processParams.midiEvent = startEvent;
+                                EventProcessFn processFn;
+                                if (processParams.sysexProcessMap.TryGetValue(psEvent.Code, out processFn))
+                                {
+                                    processFn(processParams);
+                                }
+                                break;
+                            }
+                        }
+
+                        Debug.Assert(foundMatch, $"SysEx end event without a matching start event\n{psEvent}");
+                    }
                 }
             }
 
@@ -507,129 +571,6 @@ namespace MoonscraperChartEditor.Song.IO
             }
             else
                 unrecognised.UpdateCache();
-
-            // Apply tap and open note events
-            Chart[] chartsOfInstrument;
-
-            if (instrument == Song.Instrument.Unrecognised)
-            {
-                chartsOfInstrument = new Chart[] { unrecognised };
-            }
-            else
-            {
-                chartsOfInstrument = new Chart[EnumX<Song.Difficulty>.Count];
-
-                int difficultyCount = 0;
-                foreach (Song.Difficulty difficulty in EnumX<Song.Difficulty>.Values)
-                    chartsOfInstrument[difficultyCount++] = song.GetChart(instrument, difficulty);
-            }
-
-            // Exclude drums, SysEx events that may be present don't mean anything outside of Phase Shift's Real Drums
-            // Also exclude unrecognized, we don't know what is or isn't valid on these tracks
-            if (gameMode != Chart.GameMode.Drums && gameMode != Chart.GameMode.Unrecognised)
-            {
-                for (int i = 0; i < tapAndOpenEvents.Count; ++i)
-                {
-                    var se1 = tapAndOpenEvents[i];
-                    byte[] bytes = se1.GetData();
-
-                    // Check for tap event
-                    if (bytes.Length == 8 && bytes[5] == 255 && bytes[7] == 1)
-                    {
-                        // Identified a tap section
-                        // 8 total bytes, 5th byte is FF, 7th is 1 to start, 0 to end
-                        uint tick = (uint)se1.AbsoluteTime;
-                        uint endPos = 0;
-
-                        // Find the end of the tap section
-                        for (int j = i; j < tapAndOpenEvents.Count; ++j)
-                        {
-                            var se2 = tapAndOpenEvents[j];
-                            var bytes2 = se2.GetData();
-                            /// Check for tap section end
-                            if (bytes2.Length == 8 && bytes2[5] == 255 && bytes2[7] == 0)
-                            {
-                                endPos = (uint)(se2.AbsoluteTime - tick);
-
-                                if (endPos > 0)
-                                    --endPos;
-
-                                break;
-                            }
-
-                        }
-
-                        // Apply tap property
-                        foreach (Chart chart in chartsOfInstrument)
-                        {
-                            int index, length;
-                            SongObjectHelper.GetRange(chart.notes, tick, tick + endPos, out index, out length);
-                            for (int k = index; k < index + length; ++k)
-                            {
-                                if (!chart.notes[k].IsOpenNote())
-                                {
-                                    chart.notes[k].flags = Note.Flags.Tap;
-                                }
-                            }
-                        }
-                    }
-
-                    // Check for open notes
-                    // 5th byte determines the difficulty to apply to
-                    else if (bytes.Length == 8 && bytes[5] >= 0 && bytes[5] < 4 && bytes[7] == 1)
-                    {
-                        uint tick = (uint)se1.AbsoluteTime;
-                        Song.Difficulty difficulty;
-                        switch (bytes[5])
-                        {
-                            case 0: difficulty = Song.Difficulty.Easy; break;
-                            case 1: difficulty = Song.Difficulty.Medium; break;
-                            case 2: difficulty = Song.Difficulty.Hard; break;
-                            case 3: difficulty = Song.Difficulty.Expert; break;
-                            default: continue;
-                        }
-
-                        uint endPos = 0;
-                        for (int j = i; j < tapAndOpenEvents.Count; ++j)
-                        {
-                            var se2 = tapAndOpenEvents[j] as SysexEvent;
-                            if (se2 != null)
-                            {
-                                var b2 = se2.GetData();
-                                if (b2.Length == 8 && b2[5] == bytes[5] && b2[7] == 0)
-                                {
-                                    endPos = (uint)(se2.AbsoluteTime - tick);
-
-                                    if (endPos > 0)
-                                        --endPos;
-
-                                    break;
-                                }
-                            }
-                        }
-
-                        int index, length;
-                        SongObjectCache<Note> notes = song.GetChart(instrument, difficulty).notes;
-                        SongObjectHelper.GetRange(notes, tick, tick + endPos, out index, out length);
-                        for (int k = index; k < index + length; ++k)
-                        {
-                            switch (gameMode)
-                            {
-                                case Chart.GameMode.Guitar:
-                                    notes[k].guitarFret = Note.GuitarFret.Open;
-                                    break;
-                                // Usually not used, but in the case that it is, it should work properly
-                                case Chart.GameMode.GHLGuitar:
-                                    notes[k].ghliveGuitarFret = Note.GHLiveGuitarFret.Open;
-                                    break;
-                                default:
-                                    Debug.Assert(false, $"Unhandled game mode for open note SysEx event: {gameMode}");
-                                    break;
-                            }
-                        }
-                    }
-                }
-            }
 
             // Run delayed processes
             foreach (var process in processParams.delayedProcessesList)
@@ -707,6 +648,23 @@ namespace MoonscraperChartEditor.Song.IO
 
                 default:
                     return GuitarTextEventToProcessFnMap;
+            }
+        }
+
+        static IReadOnlyDictionary<byte, EventProcessFn> GetSysExEventProcessDict(Chart.GameMode gameMode)
+        {
+            switch (gameMode)
+            {
+                case Chart.GameMode.Guitar:
+                    return GuitarSysExEventToProcessFnMap;
+                case Chart.GameMode.GHLGuitar:
+                    return GhlGuitarSysExEventToProcessFnMap;
+                case Chart.GameMode.Drums:
+                    return DrumsSysExEventToProcessFnMap;
+
+                // Don't process any SysEx events on unrecognized tracks
+                default:
+                    return new Dictionary<byte, EventProcessFn>();
             }
         }
 
@@ -1043,12 +1001,15 @@ namespace MoonscraperChartEditor.Song.IO
             var flagEvent = eventProcessParams.midiEvent as NoteOnEvent;
             Debug.Assert(flagEvent != null, $"Wrong note event type passed to {nameof(ProcessNoteOnEventAsForcedType)}. Expected: {typeof(NoteOnEvent)}, Actual: {eventProcessParams.midiEvent.GetType()}");
 
+            uint startTick = (uint)flagEvent.AbsoluteTime;
+            uint endTick = (uint)flagEvent.OffEvent.AbsoluteTime;
+
             foreach (Song.Difficulty diff in EnumX<Song.Difficulty>.Values)
             {
                 // Delay the actual processing once all the notes are actually in
                 eventProcessParams.delayedProcessesList.Add((in EventProcessParams processParams) =>
                 {
-                    ProcessNoteOnEventAsForcedTypePostDelay(processParams, flagEvent, diff, noteType);
+                    ProcessEventAsForcedTypePostDelay(processParams, startTick, endTick, diff, noteType);
                 });
             }
         }
@@ -1058,20 +1019,20 @@ namespace MoonscraperChartEditor.Song.IO
             var flagEvent = eventProcessParams.midiEvent as NoteOnEvent;
             Debug.Assert(flagEvent != null, $"Wrong note event type passed to {nameof(ProcessNoteOnEventAsForcedType)}. Expected: {typeof(NoteOnEvent)}, Actual: {eventProcessParams.midiEvent.GetType()}");
 
+            uint startTick = (uint)flagEvent.AbsoluteTime;
+            uint endTick = (uint)flagEvent.OffEvent.AbsoluteTime;
+
             // Delay the actual processing once all the notes are actually in
             eventProcessParams.delayedProcessesList.Add((in EventProcessParams processParams) =>
             {
-                ProcessNoteOnEventAsForcedTypePostDelay(processParams, flagEvent, difficulty, noteType);
+                ProcessEventAsForcedTypePostDelay(processParams, startTick, endTick, difficulty, noteType);
             });
         }
 
-        static void ProcessNoteOnEventAsForcedTypePostDelay(in EventProcessParams eventProcessParams, NoteOnEvent noteEvent, Song.Difficulty difficulty, Note.NoteType noteType)
+        static void ProcessEventAsForcedTypePostDelay(in EventProcessParams eventProcessParams, uint startTick, uint endTick, Song.Difficulty difficulty, Note.NoteType noteType)
         {
             var song = eventProcessParams.song;
             var instrument = eventProcessParams.instrument;
-
-            uint tick = (uint)noteEvent.AbsoluteTime;
-            uint endPos = (uint)(noteEvent.OffEvent.AbsoluteTime - tick);
 
             Chart chart;
             if (instrument != Song.Instrument.Unrecognised)
@@ -1080,7 +1041,7 @@ namespace MoonscraperChartEditor.Song.IO
                 chart = eventProcessParams.currentUnrecognisedChart;
 
             int index, length;
-            SongObjectHelper.GetRange(chart.notes, tick, tick + endPos, out index, out length);
+            SongObjectHelper.GetRange(chart.notes, startTick, endTick, out index, out length);
 
             uint lastChordTick = uint.MaxValue;
             bool expectedForceFailure = true; // Whether or not it is expected that the actual type will not match the expected type
@@ -1303,6 +1264,105 @@ namespace MoonscraperChartEditor.Song.IO
                     }
                 }
             }
+        }
+
+        static void ProcessSysExEventPairAsForcedType(in EventProcessParams eventProcessParams, Note.NoteType noteType)
+        {
+            var startEvent = eventProcessParams.midiEvent as PhaseShiftSysExStart;
+            Debug.Assert(startEvent != null, $"Wrong note event type passed to {nameof(ProcessSysExEventPairAsForcedType)}. Expected: {typeof(PhaseShiftSysExStart)}, Actual: {eventProcessParams.midiEvent.GetType()}");
+            var endEvent = startEvent.EndEvent;
+            Debug.Assert(endEvent != null, $"No end event supplied to {nameof(ProcessSysExEventPairAsForcedType)}.");
+
+            uint startTick = (uint)startEvent.AbsoluteTime;
+            uint endTick = (uint)endEvent.AbsoluteTime;
+
+            if (startEvent.Difficulty == MidIOHelper.SYSEX_DIFFICULTY_ALL)
+            {
+                foreach (Song.Difficulty diff in EnumX<Song.Difficulty>.Values)
+                {
+                    eventProcessParams.delayedProcessesList.Add((in EventProcessParams processParams) =>
+                    {
+                        ProcessEventAsForcedTypePostDelay(processParams, startTick, endTick, diff, noteType);
+                    });
+                }
+            }
+            else
+            {
+                var diff = MidIOHelper.SYSEX_TO_MS_DIFF_LOOKUP[startEvent.Difficulty];
+                eventProcessParams.delayedProcessesList.Add((in EventProcessParams processParams) =>
+                {
+                    ProcessEventAsForcedTypePostDelay(processParams, startTick, endTick, diff, noteType);
+                });
+            }
+        }
+
+        static void ProcessSysExEventPairAsOpenNoteModifier(in EventProcessParams eventProcessParams)
+        {
+            var startEvent = eventProcessParams.midiEvent as PhaseShiftSysExStart;
+            Debug.Assert(startEvent != null, $"Wrong note event type passed to {nameof(ProcessSysExEventPairAsOpenNoteModifier)}. Expected: {typeof(PhaseShiftSysExStart)}, Actual: {eventProcessParams.midiEvent.GetType()}");
+            var endEvent = startEvent.EndEvent;
+            Debug.Assert(endEvent != null, $"No end event supplied to {nameof(ProcessSysExEventPairAsOpenNoteModifier)}.");
+
+            uint startTick = (uint)startEvent.AbsoluteTime;
+            uint endTick = (uint)endEvent.AbsoluteTime;
+            // Exclude the last tick of the phrase
+            if (endTick > 0)
+                --endTick;
+
+            if (startEvent.Difficulty == MidIOHelper.SYSEX_DIFFICULTY_ALL)
+            {
+                foreach (Song.Difficulty diff in EnumX<Song.Difficulty>.Values)
+                {
+                    eventProcessParams.delayedProcessesList.Add((in EventProcessParams processParams) =>
+                    {
+                        ProcessEventAsOpenNoteModifierPostDelay(processParams, startTick, endTick, diff);
+                    });
+                }
+            }
+            else
+            {
+                var diff = MidIOHelper.SYSEX_TO_MS_DIFF_LOOKUP[startEvent.Difficulty];
+                eventProcessParams.delayedProcessesList.Add((in EventProcessParams processParams) =>
+                {
+                    ProcessEventAsOpenNoteModifierPostDelay(processParams, startTick, endTick, diff);
+                });
+            }
+        }
+
+        static void ProcessEventAsOpenNoteModifierPostDelay(in EventProcessParams processParams, uint startTick, uint endTick, Song.Difficulty difficulty)
+        {
+            var instrument = processParams.instrument;
+            var gameMode = Song.InstumentToChartGameMode(instrument);
+            var song = processParams.song;
+
+            Chart chart;
+            if (instrument == Song.Instrument.Unrecognised)
+                chart = processParams.currentUnrecognisedChart;
+            else
+                chart = song.GetChart(instrument, difficulty);
+
+            int index, length;
+            SongObjectHelper.GetRange(chart.notes, startTick, endTick, out index, out length);
+            for (int i = index; i < index + length; ++i)
+            {
+                switch (gameMode)
+                {
+                    case (Chart.GameMode.Guitar):
+                        chart.notes[i].guitarFret = Note.GuitarFret.Open;
+                        break;
+
+                    // Usually not used, but in the case that it is it should work properly
+                    case (Chart.GameMode.GHLGuitar):
+                        chart.notes[i].ghliveGuitarFret = Note.GHLiveGuitarFret.Open;
+                        break;
+
+                    default:
+                        Debug.Assert(false, $"Unhandled game mode for open note modifier: {gameMode} (instrument: {instrument})");
+                        break;
+                }
+            }
+
+            chart.UpdateCache();
         }
     }
 }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -552,7 +552,7 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             }
 
-            // Apply forcing events
+            // Run delayed processes
             foreach (var process in processParams.delayedProcessesList)
             {
                 process(processParams);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -38,6 +38,7 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
         {
             { MidIOHelper.BEAT_TRACK,       true },
+            { MidIOHelper.VENUE_TRACK,      true },
         };
 
         static readonly List<Song.Instrument> c_legacyStarPowerFixupWhitelist = new List<Song.Instrument>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -39,6 +39,14 @@ namespace MoonscraperChartEditor.Song.IO
             { MidIOHelper.BEAT_TRACK,       true },
         };
 
+        static readonly List<Song.Instrument> c_legacyStarPowerFixupWhitelist = new List<Song.Instrument>()
+        {
+            Song.Instrument.Guitar,
+            Song.Instrument.GuitarCoop,
+            Song.Instrument.Bass,
+            Song.Instrument.Rhythm,
+        };
+
         static readonly IReadOnlyDictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()
         {
             // String list is ordered in priority. If it finds a file names with the first string it'll skip over the rest.
@@ -603,6 +611,45 @@ namespace MoonscraperChartEditor.Song.IO
             {
                 process(processParams);
             }
+
+            // Legacy star power fixup
+            if (c_legacyStarPowerFixupWhitelist.Contains(instrument))
+            {
+                // Only need to check one difficulty since Star Power gets copied to all difficulties
+                var chart = song.GetChart(instrument, Song.Difficulty.Expert);
+                if (chart.starPower.Count == 0)
+                {
+                    foreach (var textEvent in chart.events)
+                    {
+                        if (textEvent.eventName == MidIOHelper.SOLO_EVENT_TEXT || textEvent.eventName == MidIOHelper.SOLO_END_EVENT_TEXT)
+                        {
+                            TextEvent text = track[0] as TextEvent;
+                            Debug.Assert(text != null, "Track name not found when processing legacy starpower fixups");
+                            messageList.Add(new MessageProcessParams()
+                            {
+                                message = $"No Star Power phrases were found on track {text.Text}. However, solo phrases were found. These may be legacy star power phrases.\nImport these solo phrases as Star Power?",
+                                title = "Legacy Star Power Detected",
+                                executeInEditor = true,
+                                currentSong = processParams.song,
+                                instrument = processParams.instrument,
+                                processFn = (messageParams) => {
+                                    Debug.Log("Loading solo events as Star Power");
+                                    ProcessTextEventPairAsStarpower(
+                                        new EventProcessParams()
+                                        {
+                                            song = messageParams.currentSong,
+                                            instrument = messageParams.instrument
+                                        },
+                                        MidIOHelper.SOLO_EVENT_TEXT,
+                                        MidIOHelper.SOLO_END_EVENT_TEXT
+                                    );
+                                }
+                            });
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         static IReadOnlyDictionary<int, EventProcessFn> GetNoteProcessDict(Chart.GameMode gameMode)
@@ -1164,6 +1211,70 @@ namespace MoonscraperChartEditor.Song.IO
                     {
                         // Toggle flag
                         note.flags ^= flags;
+                    }
+                }
+            }
+        }
+
+        static void ProcessTextEventPairAsStarpower(in EventProcessParams eventProcessParams, string startText, string endText, Starpower.Flags flags = Starpower.Flags.None)
+        {
+            foreach (Song.Difficulty difficulty in EnumX<Song.Difficulty>.Values)
+            {
+                var song = eventProcessParams.song;
+                var instrument = eventProcessParams.instrument;
+                var chart = song.GetChart(instrument, difficulty);
+
+                // Retrieve start and end events
+                var startEvents = new List<ChartEvent>();
+                var endEvents = new List<ChartEvent>();
+                for (int i = 0; i < chart.events.Count; ++i)
+                {
+                    var textEvent = chart.events[i];
+                    if (textEvent.eventName == startText)
+                    {
+                        startEvents.Add(textEvent);
+                    }
+                    else if (textEvent.eventName == endText)
+                    {
+                        endEvents.Add(textEvent);
+                    }
+                }
+
+                // Don't process if there aren't the same number of start and end events
+                if (startEvents.Count != endEvents.Count)
+                {
+                    Debug.LogWarning($"Mismatch between start and end event counts on {difficulty} {instrument}. Cannont continue safely, skipping.");
+                    return;
+                }
+
+                // Pair together start and end events
+                for (int endIndex = 0; endIndex < endEvents.Count; ++endIndex)
+                {
+                    var endEvent = endEvents[endIndex];
+                    Debug.Assert(endEvent != null, $"Null end event in {nameof(ProcessTextEventPairAsStarpower)}");
+                    if (endEvent == null)
+                    {
+                        continue;
+                    }
+
+                    // Start events are searched in reverse order in order to find the closest one that
+                    // doesn't start after the current end event index
+                    for (int startIndex = startEvents.Count - 1; startIndex >= 0; --startIndex)
+                    {
+                        var startEvent = startEvents[startIndex];
+                        Debug.Assert(startEvent != null, $"Null start event in {nameof(ProcessTextEventPairAsStarpower)}");
+                        if (startEvent == null)
+                        {
+                            continue;
+                        }
+
+                        if (startEvent.tick < endEvent.tick)
+                        {
+                            chart.Remove(startEvent);
+                            chart.Remove(endEvent);
+                            chart.Add(new Starpower(startEvent.tick, endEvent.tick - startEvent.tick), false);
+                            break;
+                        }
                     }
                 }
             }

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -35,8 +35,8 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
         {
-            { "t1 gems",    true },
-            { "beat",       true }
+            { MidIOHelper.GH1_GUITAR_TRACK, true },
+            { MidIOHelper.BEAT_TRACK,       true },
         };
 
         static readonly IReadOnlyDictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -222,6 +222,29 @@ namespace MoonscraperChartEditor.Song.IO
                         {
                             instrument = Song.Instrument.Unrecognised;
                         }
+                        else if (song.ChartExistsForInstrument(instrument))
+                        {
+                            messageList.Add(new MessageProcessParams()
+                            {
+                                message = $"A track was already loaded for instrument {instrument}, but another track was found for this instrument: {trackNameKey}\nWould you like to overwrite the currently loaded track?",
+                                title = "Duplicate Instrument Track Found",
+                                executeInEditor = false,
+                                currentSong = song,
+                                trackNumber = i,
+                                processFn = (MessageProcessParams processParams) => {
+                                    Debug.Log($"Overwriting already-loaded part {processParams.instrument}");
+                                    foreach (Song.Difficulty difficulty in EnumX<Song.Difficulty>.Values)
+                                    {
+                                        var chart = processParams.currentSong.GetChart(processParams.instrument, difficulty);
+                                        chart.Clear();
+                                        chart.UpdateCache();
+                                    }
+
+                                    ReadNotes(midi.Events[processParams.trackNumber], processParams.currentSong, processParams.instrument);
+                                }
+                            });
+                            break;
+                        }
 
                         Debug.LogFormat("Loading midi track {0}", instrument);
                         ReadNotes(track, song, instrument);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/PhaseShiftSysEx.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/PhaseShiftSysEx.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-2020 Alexander Ong
+// See LICENSE in project root for license information.
+
+using System;
+using NAudio.Midi;
+
+namespace MoonscraperChartEditor.Song.IO
+{
+    public class PhaseShiftSysEx : MidiEvent
+    {
+        public byte Type;
+        public byte Difficulty;
+        public byte Code;
+        public byte Value;
+
+        protected PhaseShiftSysEx()
+        { }
+
+        protected PhaseShiftSysEx(PhaseShiftSysEx other)
+        {
+            AbsoluteTime = other.AbsoluteTime;
+            Type = other.Type;
+            Difficulty = other.Difficulty;
+            Code = other.Code;
+            Value = other.Value;
+        }
+
+        public PhaseShiftSysEx(SysexEvent sysex) : base(sysex.AbsoluteTime, sysex.Channel, sysex.CommandCode)
+        {
+            if (!TryParseInternal(sysex, this))
+            {
+                throw new ArgumentException("The given event data is not a Phase Shift SysEx event.", nameof(sysex));
+            }
+        }
+
+        public static bool TryParse(SysexEvent sysex, out PhaseShiftSysEx psSysex)
+        {
+            psSysex = new PhaseShiftSysEx();
+            return TryParseInternal(sysex, psSysex);
+        }
+
+        protected static bool TryParseInternal(SysexEvent sysex, PhaseShiftSysEx psSysex)
+        {
+            byte[] sysexData = sysex.GetData();
+            if (IsPhaseShiftSysex(sysexData))
+            {
+                psSysex.AbsoluteTime = sysex.AbsoluteTime;
+                psSysex.Type = sysexData[MidIOHelper.SYSEX_INDEX_TYPE];
+                psSysex.Difficulty = sysexData[MidIOHelper.SYSEX_INDEX_DIFFICULTY];
+                psSysex.Code = sysexData[MidIOHelper.SYSEX_INDEX_CODE];
+                psSysex.Value = sysexData[MidIOHelper.SYSEX_INDEX_VALUE];
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool IsPhaseShiftSysex(byte[] sysexData)
+        {
+            if (sysexData == null)
+                throw new ArgumentNullException(nameof(sysexData));
+
+            return (
+                sysexData.Length == MidIOHelper.SYSEX_LENGTH &&
+                sysexData[MidIOHelper.SYSEX_INDEX_HEADER_1] == MidIOHelper.SYSEX_HEADER_1 &&
+                sysexData[MidIOHelper.SYSEX_INDEX_HEADER_2] == MidIOHelper.SYSEX_HEADER_2 &&
+                sysexData[MidIOHelper.SYSEX_INDEX_HEADER_3] == MidIOHelper.SYSEX_HEADER_3
+            );
+        }
+
+        public bool MatchesWith(PhaseShiftSysEx otherEvent)
+        {
+            return Type == otherEvent.Type && Difficulty == otherEvent.Difficulty && Code == otherEvent.Code;
+        }
+
+        public override string ToString()
+        {
+            return $"AbsoluteTime: {AbsoluteTime}, Type: {Type}, Difficulty: {Difficulty}, Code: {Code}, Value: {Value}";
+        }
+    }
+
+    public class PhaseShiftSysExStart : PhaseShiftSysEx
+    {
+        private PhaseShiftSysEx endEvent;
+        public PhaseShiftSysEx EndEvent
+        {
+            get => endEvent;
+            set
+            {
+                if (value.AbsoluteTime < AbsoluteTime)
+                    throw new ArgumentException($"The end event of a SysEx pair must occur after the start event.\nStart: {this}\nEnd: {value}", nameof(value));
+
+                endEvent = value;
+            }
+        }
+
+        public long Length
+        {
+            get
+            {
+                if (EndEvent != null)
+                {
+                    return EndEvent.AbsoluteTime - AbsoluteTime;
+                }
+
+                // No end event to get a length from
+                return 0;
+            }
+        }
+
+        public PhaseShiftSysExStart(PhaseShiftSysEx sysex) : base(sysex)
+        { }
+
+        public PhaseShiftSysExStart(PhaseShiftSysEx start, PhaseShiftSysEx end) : base(start)
+        {
+            if (start.AbsoluteTime < end.AbsoluteTime)
+                throw new ArgumentException($"The start event of a SysEx pair must occur before the end event.\nStart: {start}\nEnd: {end}", nameof(start));
+
+            EndEvent = end;
+        }
+
+        public override string ToString()
+        {
+            if (EndEvent != null)
+                return $"AbsoluteTime: {AbsoluteTime}, Length: {Length}, Type: {Type}, Difficulty: {Difficulty}, Code: {Code}, Value: {Value}";
+            else
+                return base.ToString();
+        }
+    }
+}

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/PhaseShiftSysEx.cs.meta
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/PhaseShiftSysEx.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3942c4500cae6246aa8d3a24ee4a618
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Song.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/Song.cs
@@ -218,6 +218,28 @@ namespace MoonscraperChartEditor.Song
             }
         }
 
+        public bool ChartExistsForInstrument(Instrument instrument)
+        {
+            try
+            {
+                int startIndex = (int)instrument * EnumX<Difficulty>.Count;
+                for (int i = startIndex; i < startIndex + EnumX<Difficulty>.Count; i++)
+                {
+                    if (charts[i].chartObjects.Count != 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+                return false;
+            }
+        }
+
         /// <summary>
         /// Converts a time value into a tick position value. May be inaccurate due to interger rounding.
         /// </summary>


### PR DESCRIPTION
Summary:
- Implement system for .mid parsing actions that require user intervention
- Add legacy SP fixups, prompted by a message
- Add handling and message for duplicate tracks
- Allow `T1 GEMS` to be parsed as a guitar track
- Parse `PART DRUMS_REAL_PS` as a drums track
- Add `VENUE` to exclusion map
- Rewrite SysEx event parsing to be much more robust and defined
- Rewrite SysEx event writing to utilize common code and constants