### PR TITLE
Allow `T1 GEMS` and `PART DRUMS_REAL_PS` to be parsed; exclude `VENUE` track from parsing

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidIOHelper.cs
@@ -10,13 +10,17 @@ namespace MoonscraperChartEditor.Song.IO
     public static class MidIOHelper
     {
         // Track names
+        public const string BEAT_TRACK = "BEAT";
         public const string EVENTS_TRACK = "EVENTS";
+        public const string VENUE_TRACK = "VENUE";
         public const string GUITAR_TRACK = "PART GUITAR";
+        public const string GH1_GUITAR_TRACK = "T1 GEMS";
         public const string GUITAR_COOP_TRACK = "PART GUITAR COOP";
         public const string BASS_TRACK = "PART BASS";
         public const string RHYTHM_TRACK = "PART RHYTHM";
         public const string KEYS_TRACK = "PART KEYS";
         public const string DRUMS_TRACK = "PART DRUMS";
+        public const string DRUMS_REAL_TRACK = "PART REAL_DRUMS_PS";
         public const string GHL_GUITAR_TRACK = "PART GUITAR GHL";
         public const string GHL_BASS_TRACK = "PART BASS GHL";
         public const string GHL_RHYTHM_TRACK = "PART RHYTHM GHL";

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -22,11 +22,13 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly IReadOnlyDictionary<string, Song.Instrument> c_trackNameToInstrumentMap = new Dictionary<string, Song.Instrument>()
         {
             { MidIOHelper.GUITAR_TRACK,        Song.Instrument.Guitar },
+            { MidIOHelper.GH1_GUITAR_TRACK,    Song.Instrument.Guitar },
             { MidIOHelper.GUITAR_COOP_TRACK,   Song.Instrument.GuitarCoop },
             { MidIOHelper.BASS_TRACK,          Song.Instrument.Bass },
             { MidIOHelper.RHYTHM_TRACK,        Song.Instrument.Rhythm },
             { MidIOHelper.KEYS_TRACK,          Song.Instrument.Keys },
             { MidIOHelper.DRUMS_TRACK,         Song.Instrument.Drums },
+            { MidIOHelper.DRUMS_REAL_TRACK,    Song.Instrument.Drums },
             { MidIOHelper.GHL_GUITAR_TRACK,    Song.Instrument.GHLiveGuitar },
             { MidIOHelper.GHL_BASS_TRACK,      Song.Instrument.GHLiveBass },
             { MidIOHelper.GHL_RHYTHM_TRACK,    Song.Instrument.GHLiveRhythm },
@@ -35,7 +37,6 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
         {
-            { MidIOHelper.GH1_GUITAR_TRACK, true },
             { MidIOHelper.BEAT_TRACK,       true },
         };
 

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -38,6 +38,7 @@ namespace MoonscraperChartEditor.Song.IO
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
         {
             { MidIOHelper.BEAT_TRACK,       true },
+            { MidIOHelper.VENUE_TRACK,      true },
         };
 
         static readonly IReadOnlyDictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -35,8 +35,8 @@ namespace MoonscraperChartEditor.Song.IO
 
         static readonly IReadOnlyDictionary<string, bool> c_trackExcludesMap = new Dictionary<string, bool>()
         {
-            { "t1 gems",    true },
-            { "beat",       true }
+            { MidIOHelper.GH1_GUITAR_TRACK, true },
+            { MidIOHelper.BEAT_TRACK,       true },
         };
 
         static readonly IReadOnlyDictionary<Song.AudioInstrument, string[]> c_audioStreamLocationOverrideDict = new Dictionary<Song.AudioInstrument, string[]>()


### PR DESCRIPTION
This depends on #91 to work as intended, as that includes some duplicate track checking and prompting.

Closes #38.