### PR TITLE
Some small and quick fixes

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/GroupSelectPanelController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/Inspectors/GroupSelectPanelController.cs
@@ -300,12 +300,12 @@ public class GroupSelectPanelController : MonoBehaviour
 
     public void SetTom()
     {
-        SetNoteType(Note.NoteType.Natural, Note.Flags.ProDrums_Accent | Note.Flags.ProDrums_Ghost);
+        SetNoteType(Note.NoteType.Natural, Note.Flags.ProDrums_Accent | Note.Flags.ProDrums_Ghost | Note.Flags.DoubleKick);
     }
 
     public void SetCymbal()
     {
-        SetNoteType(Note.NoteType.Cymbal, Note.Flags.ProDrums_Accent | Note.Flags.ProDrums_Ghost);
+        SetNoteType(Note.NoteType.Cymbal, Note.Flags.ProDrums_Accent | Note.Flags.ProDrums_Ghost | Note.Flags.DoubleKick);
     }
 
     public void SetNoDynamics()


### PR DESCRIPTION
- Fix SysEx-marked open notes being forced incorrectly in .mid charts, by separating the forcing and SysEx process lists and processing SysEx events first
  - Back to square one in a way lol, this is how it worked before I refactored SysEx events.

- Fix the Tom button in the group selection menu removing the 2x kick flag on kicks, and ensure the Cymbal button will never do the same (it worked fine before, but might as well do it for parity)

- Fix the lyric editor throwing an exception if it was closed before finishing a phrase, and then re-opened (moved to #114, see that PR for more info)