### PR TITLE
Band-aid fix for lyric editor throwing an exception when re-opening with an incomplete phrase

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/UI/LyricEditor2/LyricEditor2PhraseController.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/UI/LyricEditor2/LyricEditor2PhraseController.cs
@@ -125,12 +125,12 @@ public class LyricEditor2PhraseController : UnityEngine.MonoBehaviour, System.IC
 
     public void PickupPhraseStart() 
     {
-        phraseStartEvent.Pickup().Invoke();
+        phraseStartEvent.Pickup()?.Invoke();
     }
 
     public void PickupPhraseEnd() 
     {
-        phraseEndEvent.Pickup().Invoke();
+        phraseEndEvent.Pickup()?.Invoke();
     }
 
     // Initialize lyricEvents using a list of string syllables. Syllables which


### PR DESCRIPTION
Separated out from #113 at FireFox's request; not a permanent solution

Fix the lyric editor throwing an exception if it was closed before finishing a phrase, and then re-opened.

I'm not sure if the fix I did was ideal lol, I'm unfamiliar with the lyric editor so I went with the easiest option and it seems to work fine. The problem has to do with the controller of the final phrase in the list never getting its `phraseEndEvent` initialized with an actual event in this scenario, so `PickupPhraseEnd` never receives a command instance and fails.