### PR TITLE
Fix issues with saving and tempo change rounding

### DIFF
--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidReader.cs
@@ -344,7 +344,7 @@ namespace MoonscraperChartEditor.Song.IO
         {
             foreach (var tempo in tempoMap.GetTempoChanges())
             {
-                song.Add(new BPM((uint)tempo.Time, (uint)(tempo.Value.BeatsPerMinute * 1000)), false);
+                song.Add(new BPM((uint)tempo.Time, (uint)Math.Round(tempo.Value.BeatsPerMinute * 1000)), false);
             }
             foreach (var timesig in tempoMap.GetTimeSignatureChanges())
             {

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -277,7 +277,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             byte[] header = GetMidiHeader(1, track_count, (short)(exportOptions.targetResolution));
 
-            FileStream file = File.Open(path, FileMode.OpenOrCreate);
+            FileStream file = File.Open(path, FileMode.Create);
             BinaryWriter bw = new BinaryWriter(file);
 
             bw.Write(header);

--- a/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
+++ b/Moonscraper Chart Editor/Assets/Scripts/Game/Charts/IO/Midi/MidWriter.cs
@@ -966,7 +966,7 @@ namespace MoonscraperChartEditor.Song.IO
             bytes[2] = 0x03;            // Size
 
             // Microseconds per quarter note for the last 3 bytes stored as a 24-bit binary
-            byte[] microPerSec = EndianBitConverter.Big.GetBytes((uint)(6.0f * Mathf.Pow(10, 10) / bpm.value));
+            byte[] microPerSec = EndianBitConverter.Big.GetBytes((uint)Mathf.Round(6.0f * Mathf.Pow(10, 10) / bpm.value));
 
             Array.Copy(microPerSec, 1, bytes, 3, 3);        // Offset of 1 and length of 3 cause 24 bit
 


### PR DESCRIPTION
* Use `Create` instead of `OpenOrCreate` so that a file is fully overwritten when saving over the top of an existing file, otherwise we were getting corrupted midi files
* Round tempo changes so that we don't end up with rounding errors in our tempo changes